### PR TITLE
Fix building on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ env:
     - BUILD_TEST="build test"
     - ENABLE_CODE_COVERAGE="-enableCodeCoverage YES"
     - PROJECT_LIBRARY="SPTPersistentCache.xcodeproj"
-    - PROJECT_DEMO="SPTPersistentCacheDemo.xcodeproj"
-    - PROJECT_FRAMEWORK="SPTPersistentCacheFramework.xcodeproj"
+    - PROJECT_DEMO="SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj"
+    - PROJECT_FRAMEWORK="SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj"
     - PODSPEC="SPTPersistentCache.podspec"
   matrix:
     - TEST_SDK=iphonesimulator  TEST_DEST="platform=iOS Simulator,OS=8.1,name=iPhone 6"   SCHEME="$SCHEME_IOS_LIBRARY"            BUILD_ACTIONS="$BUILD_TEST" EXTRA_ARGUMENTS="$ENABLE_CODE_COVERAGE" PROJECT="$PROJECT_LIBRARY"

--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -476,10 +476,6 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				OTHER_LDFLAGS = (
 					"-ObjC",

--- a/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
+++ b/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0510FF121BA2FF7A00ED0766"
+               BuildableName = "libSPTPersistentCache.a"
+               BlueprintName = "SPTPersistentCache"
+               ReferencedContainer = "container:SPTPersistentCache.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0510FF1D1BA2FF7A00ED0766"
+               BuildableName = "SPTPersistentCacheTests.xctest"
+               BlueprintName = "SPTPersistentCacheTests"
+               ReferencedContainer = "container:SPTPersistentCache.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0510FF121BA2FF7A00ED0766"
+            BuildableName = "libSPTPersistentCache.a"
+            BlueprintName = "SPTPersistentCache"
+            ReferencedContainer = "container:SPTPersistentCache.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0510FF121BA2FF7A00ED0766"
+            BuildableName = "libSPTPersistentCache.a"
+            BlueprintName = "SPTPersistentCache"
+            ReferencedContainer = "container:SPTPersistentCache.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0510FF121BA2FF7A00ED0766"
+            BuildableName = "libSPTPersistentCache.a"
+            BlueprintName = "SPTPersistentCache"
+            ReferencedContainer = "container:SPTPersistentCache.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		055726111C65280000EF6787 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		055726181C65283200EF6787 /* SPTPersistentCache.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SPTPersistentCache.xcodeproj; path = ../SPTPersistentCache.xcodeproj; sourceTree = "<group>"; };
 		C48AE7AE1C76159000814D7D /* libSPTPersistentCache.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPTPersistentCache.a; path = "/Library/Developer/Xcode/DerivedData/SPTPersistentCache-baozpsdxvsedctakhrddpkmkyjzd/Build/Products/Debug/libSPTPersistentCache.a"; sourceTree = "<absolute>"; };
+		DD1D23C21C779BAE00D0477A /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = project.xcconfig; path = ../project.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +110,7 @@
 		055726171C65282100EF6787 /* Build System */ = {
 			isa = PBXGroup;
 			children = (
+				DD1D23C21C779BAE00D0477A /* project.xcconfig */,
 				C48AE7AE1C76159000814D7D /* libSPTPersistentCache.a */,
 				055726181C65283200EF6787 /* SPTPersistentCache.xcodeproj */,
 			);
@@ -249,43 +251,13 @@
 /* Begin XCBuildConfiguration section */
 		055726121C65280000EF6787 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD1D23C21C779BAE00D0477A /* project.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -293,35 +265,11 @@
 		};
 		055726131C65280000EF6787 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD1D23C21C779BAE00D0477A /* project.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -335,7 +283,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				HEADER_SEARCH_PATHS = ../include;
 				INFOPLIST_FILE = SPTPersistentCacheDemo/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.SPTPersistentCacheDemo;
 				PRODUCT_NAME = SPTPersistentCacheDemo;
 			};
@@ -347,7 +294,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				HEADER_SEARCH_PATHS = ../include;
 				INFOPLIST_FILE = SPTPersistentCacheDemo/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.SPTPersistentCacheDemo;
 				PRODUCT_NAME = SPTPersistentCacheDemo;
 			};

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0557260D1C65280000EF6787 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0557260C1C65280000EF6787 /* Assets.xcassets */; };
 		055726101C65280000EF6787 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0557260E1C65280000EF6787 /* LaunchScreen.storyboard */; };
 		C48AE7AF1C76159000814D7D /* libSPTPersistentCache.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C48AE7AE1C76159000814D7D /* libSPTPersistentCache.a */; };
+		DD1D23C41C779D4000D0477A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1D23C31C779D4000D0477A /* UIKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		055726181C65283200EF6787 /* SPTPersistentCache.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SPTPersistentCache.xcodeproj; path = ../SPTPersistentCache.xcodeproj; sourceTree = "<group>"; };
 		C48AE7AE1C76159000814D7D /* libSPTPersistentCache.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPTPersistentCache.a; path = "/Library/Developer/Xcode/DerivedData/SPTPersistentCache-baozpsdxvsedctakhrddpkmkyjzd/Build/Products/Debug/libSPTPersistentCache.a"; sourceTree = "<absolute>"; };
 		DD1D23C21C779BAE00D0477A /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = project.xcconfig; path = ../project.xcconfig; sourceTree = "<group>"; };
+		DD1D23C31C779D4000D0477A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD1D23C41C779D4000D0477A /* UIKit.framework in Frameworks */,
 				C48AE7AF1C76159000814D7D /* libSPTPersistentCache.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -110,6 +113,7 @@
 		055726171C65282100EF6787 /* Build System */ = {
 			isa = PBXGroup;
 			children = (
+				DD1D23C31C779D4000D0477A /* UIKit.framework */,
 				DD1D23C21C779BAE00D0477A /* project.xcconfig */,
 				C48AE7AE1C76159000814D7D /* libSPTPersistentCache.a */,
 				055726181C65283200EF6787 /* SPTPersistentCache.xcodeproj */,

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/project.pbxproj
@@ -95,7 +95,7 @@
 				055726111C65280000EF6787 /* Info.plist */,
 				055725FD1C65280000EF6787 /* Supporting Files */,
 			);
-			name = SPTPersistentCacheDemo;
+			path = SPTPersistentCacheDemo;
 			sourceTree = "<group>";
 		};
 		055725FD1C65280000EF6787 /* Supporting Files */ = {

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/xcshareddata/xcschemes/SPTPersistentCacheDemo.xcscheme
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/xcshareddata/xcschemes/SPTPersistentCacheDemo.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "055725F91C65280000EF6787"
+               BuildableName = "SPTPersistentCacheDemo.app"
+               BlueprintName = "SPTPersistentCacheDemo"
+               ReferencedContainer = "container:SPTPersistentCacheDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "055725F91C65280000EF6787"
+            BuildableName = "SPTPersistentCacheDemo.app"
+            BlueprintName = "SPTPersistentCacheDemo"
+            ReferencedContainer = "container:SPTPersistentCacheDemo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "055725F91C65280000EF6787"
+            BuildableName = "SPTPersistentCacheDemo.app"
+            BlueprintName = "SPTPersistentCacheDemo"
+            ReferencedContainer = "container:SPTPersistentCacheDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "055725F91C65280000EF6787"
+            BuildableName = "SPTPersistentCacheDemo.app"
+            BlueprintName = "SPTPersistentCacheDemo"
+            ReferencedContainer = "container:SPTPersistentCacheDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo/DetailViewController.m
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo/DetailViewController.m
@@ -46,7 +46,7 @@
 {
     // Update the user interface for the detail item.
     if (self.detailItem) {
-        [self.persistentDataCache loadDataForKey:[NSString stringWithFormat:@"%u", [self.detailItem hash]]
+        [self.persistentDataCache loadDataForKey:[NSString stringWithFormat:@"%lu", (unsigned long)[self.detailItem hash]]
                                     withCallback:^(SPTPersistentCacheResponse *response) {
                                         if (response.result != SPTPersistentCacheResponseCodeOperationSucceeded) {
                                             NSLog(@"Failed: %@", response.error);

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -7,62 +7,78 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		052021C31C737E66003A4FB4 /* crc32iso3309.c in Sources */ = {isa = PBXBuildFile; fileRef = 052021B71C737E66003A4FB4 /* crc32iso3309.c */; };
-		052021C41C737E66003A4FB4 /* crc32iso3309.h in Headers */ = {isa = PBXBuildFile; fileRef = 052021B81C737E66003A4FB4 /* crc32iso3309.h */; };
-		052021C51C737E66003A4FB4 /* SPTPersistentCacheResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021B91C737E66003A4FB4 /* SPTPersistentCacheResponse.m */; };
-		052021C61C737E66003A4FB4 /* SPTPersistentCacheResponse+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 052021BA1C737E66003A4FB4 /* SPTPersistentCacheResponse+Private.h */; };
-		052021C71C737E66003A4FB4 /* SPTPersistentCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BB1C737E66003A4FB4 /* SPTPersistentCache.m */; };
-		052021C81C737E66003A4FB4 /* SPTPersistentCache+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 052021BC1C737E66003A4FB4 /* SPTPersistentCache+Private.h */; };
-		052021C91C737E66003A4FB4 /* SPTPersistentCacheHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BD1C737E66003A4FB4 /* SPTPersistentCacheHeader.m */; };
-		052021CA1C737E66003A4FB4 /* SPTPersistentCacheOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BE1C737E66003A4FB4 /* SPTPersistentCacheOptions.m */; };
-		052021CB1C737E66003A4FB4 /* SPTPersistentCacheRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BF1C737E66003A4FB4 /* SPTPersistentCacheRecord.m */; };
-		052021CC1C737E66003A4FB4 /* SPTPersistentCacheRecord+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 052021C01C737E66003A4FB4 /* SPTPersistentCacheRecord+Private.h */; };
-		052021CD1C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 052021C11C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.h */; };
-		052021CE1C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021C21C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m */; };
-		052021D11C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 052021CF1C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.h */; };
-		052021D21C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021D01C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m */; };
-		052021FE1C738392003A4FB4 /* crc32iso3309.c in Sources */ = {isa = PBXBuildFile; fileRef = 052021B71C737E66003A4FB4 /* crc32iso3309.c */; };
-		052021FF1C738392003A4FB4 /* SPTPersistentCacheResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021B91C737E66003A4FB4 /* SPTPersistentCacheResponse.m */; };
-		052022001C738392003A4FB4 /* SPTPersistentCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BB1C737E66003A4FB4 /* SPTPersistentCache.m */; };
-		052022011C738392003A4FB4 /* SPTPersistentCacheHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BD1C737E66003A4FB4 /* SPTPersistentCacheHeader.m */; };
-		052022021C738392003A4FB4 /* SPTPersistentCacheOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BE1C737E66003A4FB4 /* SPTPersistentCacheOptions.m */; };
-		052022031C738392003A4FB4 /* SPTPersistentCacheRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021BF1C737E66003A4FB4 /* SPTPersistentCacheRecord.m */; };
-		052022041C738392003A4FB4 /* SPTPersistentCacheTimerProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021C21C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m */; };
-		052022051C738392003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 052021D01C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m */; };
-		C48AE7BF1C76174600814D7D /* SPTPersistentCacheTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = C48AE7B91C76174600814D7D /* SPTPersistentCacheTypes.h */; };
-		C48AE7C01C76174600814D7D /* SPTPersistentCache.h in Headers */ = {isa = PBXBuildFile; fileRef = C48AE7BA1C76174600814D7D /* SPTPersistentCache.h */; };
-		C48AE7C11C76174600814D7D /* SPTPersistentCacheOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = C48AE7BB1C76174600814D7D /* SPTPersistentCacheOptions.h */; };
-		C48AE7C21C76174600814D7D /* SPTPersistentCacheHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = C48AE7BC1C76174600814D7D /* SPTPersistentCacheHeader.h */; };
-		C48AE7C31C76174600814D7D /* SPTPersistentCacheRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = C48AE7BD1C76174600814D7D /* SPTPersistentCacheRecord.h */; };
-		C48AE7C41C76174600814D7D /* SPTPersistentCacheResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = C48AE7BE1C76174600814D7D /* SPTPersistentCacheResponse.h */; };
+		DD1D237F1C77857900D0477A /* SPTPersistentCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23791C77857900D0477A /* SPTPersistentCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23801C77857900D0477A /* SPTPersistentCacheHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237A1C77857900D0477A /* SPTPersistentCacheHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23811C77857900D0477A /* SPTPersistentCacheOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237B1C77857900D0477A /* SPTPersistentCacheOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23821C77857900D0477A /* SPTPersistentCacheRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237C1C77857900D0477A /* SPTPersistentCacheRecord.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23831C77857900D0477A /* SPTPersistentCacheResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237D1C77857900D0477A /* SPTPersistentCacheResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23841C77857900D0477A /* SPTPersistentCacheTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237E1C77857900D0477A /* SPTPersistentCacheTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23851C77857E00D0477A /* SPTPersistentCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23791C77857900D0477A /* SPTPersistentCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23861C77857E00D0477A /* SPTPersistentCacheHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237A1C77857900D0477A /* SPTPersistentCacheHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23871C77857E00D0477A /* SPTPersistentCacheOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237B1C77857900D0477A /* SPTPersistentCacheOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23881C77857E00D0477A /* SPTPersistentCacheRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237C1C77857900D0477A /* SPTPersistentCacheRecord.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D23891C77857E00D0477A /* SPTPersistentCacheResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237D1C77857900D0477A /* SPTPersistentCacheResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D238A1C77857E00D0477A /* SPTPersistentCacheTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237E1C77857900D0477A /* SPTPersistentCacheTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD1D239E1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D238C1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.h */; };
+		DD1D239F1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D238D1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m */; };
+		DD1D23A21C7785A900D0477A /* crc32iso3309.c in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23901C7785A900D0477A /* crc32iso3309.c */; };
+		DD1D23A31C7785A900D0477A /* crc32iso3309.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23911C7785A900D0477A /* crc32iso3309.h */; };
+		DD1D23A41C7785A900D0477A /* SPTPersistentCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23921C7785A900D0477A /* SPTPersistentCache.m */; };
+		DD1D23A51C7785A900D0477A /* SPTPersistentCache+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23931C7785A900D0477A /* SPTPersistentCache+Private.h */; };
+		DD1D23A61C7785A900D0477A /* SPTPersistentCacheFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23941C7785A900D0477A /* SPTPersistentCacheFileManager.h */; };
+		DD1D23A71C7785A900D0477A /* SPTPersistentCacheFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23951C7785A900D0477A /* SPTPersistentCacheFileManager.m */; };
+		DD1D23A81C7785A900D0477A /* SPTPersistentCacheHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23961C7785A900D0477A /* SPTPersistentCacheHeader.m */; };
+		DD1D23A91C7785A900D0477A /* SPTPersistentCacheOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23971C7785A900D0477A /* SPTPersistentCacheOptions.m */; };
+		DD1D23AA1C7785A900D0477A /* SPTPersistentCacheRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23981C7785A900D0477A /* SPTPersistentCacheRecord.m */; };
+		DD1D23AB1C7785A900D0477A /* SPTPersistentCacheRecord+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23991C7785A900D0477A /* SPTPersistentCacheRecord+Private.h */; };
+		DD1D23AC1C7785A900D0477A /* SPTPersistentCacheResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D239A1C7785A900D0477A /* SPTPersistentCacheResponse.m */; };
+		DD1D23AD1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D239B1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h */; };
+		DD1D23AE1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D239C1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h */; };
+		DD1D23AF1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D239D1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m */; };
+		DD1D23B21C7785AE00D0477A /* crc32iso3309.c in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23901C7785A900D0477A /* crc32iso3309.c */; };
+		DD1D23B31C7785AE00D0477A /* crc32iso3309.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23911C7785A900D0477A /* crc32iso3309.h */; };
+		DD1D23B41C7785AE00D0477A /* SPTPersistentCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23921C7785A900D0477A /* SPTPersistentCache.m */; };
+		DD1D23B51C7785AE00D0477A /* SPTPersistentCache+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23931C7785A900D0477A /* SPTPersistentCache+Private.h */; };
+		DD1D23B61C7785AE00D0477A /* SPTPersistentCacheFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23941C7785A900D0477A /* SPTPersistentCacheFileManager.h */; };
+		DD1D23B71C7785AE00D0477A /* SPTPersistentCacheFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23951C7785A900D0477A /* SPTPersistentCacheFileManager.m */; };
+		DD1D23B81C7785AE00D0477A /* SPTPersistentCacheHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23961C7785A900D0477A /* SPTPersistentCacheHeader.m */; };
+		DD1D23B91C7785AE00D0477A /* SPTPersistentCacheOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23971C7785A900D0477A /* SPTPersistentCacheOptions.m */; };
+		DD1D23BA1C7785AE00D0477A /* SPTPersistentCacheRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D23981C7785A900D0477A /* SPTPersistentCacheRecord.m */; };
+		DD1D23BB1C7785AE00D0477A /* SPTPersistentCacheRecord+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23991C7785A900D0477A /* SPTPersistentCacheRecord+Private.h */; };
+		DD1D23BC1C7785AE00D0477A /* SPTPersistentCacheResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D239A1C7785A900D0477A /* SPTPersistentCacheResponse.m */; };
+		DD1D23BD1C7785AE00D0477A /* SPTPersistentCacheResponse+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D239B1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h */; };
+		DD1D23BE1C7785AE00D0477A /* SPTPersistentCacheTimerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D239C1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h */; };
+		DD1D23BF1C7785AE00D0477A /* SPTPersistentCacheTimerProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1D239D1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		0520219C1C737DBE003A4FB4 /* SPTPersistentCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTPersistentCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		052021B71C737E66003A4FB4 /* crc32iso3309.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = crc32iso3309.c; path = ../Sources/crc32iso3309.c; sourceTree = "<group>"; };
-		052021B81C737E66003A4FB4 /* crc32iso3309.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc32iso3309.h; path = ../Sources/crc32iso3309.h; sourceTree = "<group>"; };
-		052021B91C737E66003A4FB4 /* SPTPersistentCacheResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheResponse.m; path = ../Sources/SPTPersistentCacheResponse.m; sourceTree = "<group>"; };
-		052021BA1C737E66003A4FB4 /* SPTPersistentCacheResponse+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SPTPersistentCacheResponse+Private.h"; path = "../Sources/SPTPersistentCacheResponse+Private.h"; sourceTree = "<group>"; };
-		052021BB1C737E66003A4FB4 /* SPTPersistentCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCache.m; path = ../Sources/SPTPersistentCache.m; sourceTree = "<group>"; };
-		052021BC1C737E66003A4FB4 /* SPTPersistentCache+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SPTPersistentCache+Private.h"; path = "../Sources/SPTPersistentCache+Private.h"; sourceTree = "<group>"; };
-		052021BD1C737E66003A4FB4 /* SPTPersistentCacheHeader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheHeader.m; path = ../Sources/SPTPersistentCacheHeader.m; sourceTree = "<group>"; };
-		052021BE1C737E66003A4FB4 /* SPTPersistentCacheOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheOptions.m; path = ../Sources/SPTPersistentCacheOptions.m; sourceTree = "<group>"; };
-		052021BF1C737E66003A4FB4 /* SPTPersistentCacheRecord.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheRecord.m; path = ../Sources/SPTPersistentCacheRecord.m; sourceTree = "<group>"; };
-		052021C01C737E66003A4FB4 /* SPTPersistentCacheRecord+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SPTPersistentCacheRecord+Private.h"; path = "../Sources/SPTPersistentCacheRecord+Private.h"; sourceTree = "<group>"; };
-		052021C11C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCacheTimerProxy.h; path = ../Sources/SPTPersistentCacheTimerProxy.h; sourceTree = "<group>"; };
-		052021C21C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheTimerProxy.m; path = ../Sources/SPTPersistentCacheTimerProxy.m; sourceTree = "<group>"; };
-		052021CF1C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SPTPersistentCacheDomainErrors.h"; path = "../Sources/Categories/NSError+SPTPersistentCacheDomainErrors.h"; sourceTree = "<group>"; };
-		052021D01C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SPTPersistentCacheDomainErrors.m"; path = "../Sources/Categories/NSError+SPTPersistentCacheDomainErrors.m"; sourceTree = "<group>"; };
 		052021F21C738048003A4FB4 /* SPTPersistentCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTPersistentCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		052021FB1C7382C6003A4FB4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		052022061C738600003A4FB4 /* project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = project.xcconfig; path = ../project.xcconfig; sourceTree = "<group>"; };
 		052022091C738637003A4FB4 /* spotify_os.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = spotify_os.xcconfig; path = ../spotify_os.xcconfig; sourceTree = "<group>"; };
-		C48AE7B91C76174600814D7D /* SPTPersistentCacheTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCacheTypes.h; path = ../include/SPTPersistentCache/SPTPersistentCacheTypes.h; sourceTree = "<group>"; };
-		C48AE7BA1C76174600814D7D /* SPTPersistentCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCache.h; path = ../include/SPTPersistentCache/SPTPersistentCache.h; sourceTree = "<group>"; };
-		C48AE7BB1C76174600814D7D /* SPTPersistentCacheOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCacheOptions.h; path = ../include/SPTPersistentCache/SPTPersistentCacheOptions.h; sourceTree = "<group>"; };
-		C48AE7BC1C76174600814D7D /* SPTPersistentCacheHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCacheHeader.h; path = ../include/SPTPersistentCache/SPTPersistentCacheHeader.h; sourceTree = "<group>"; };
-		C48AE7BD1C76174600814D7D /* SPTPersistentCacheRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCacheRecord.h; path = ../include/SPTPersistentCache/SPTPersistentCacheRecord.h; sourceTree = "<group>"; };
-		C48AE7BE1C76174600814D7D /* SPTPersistentCacheResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTPersistentCacheResponse.h; path = ../include/SPTPersistentCache/SPTPersistentCacheResponse.h; sourceTree = "<group>"; };
+		DD1D23791C77857900D0477A /* SPTPersistentCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCache.h; sourceTree = "<group>"; };
+		DD1D237A1C77857900D0477A /* SPTPersistentCacheHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheHeader.h; sourceTree = "<group>"; };
+		DD1D237B1C77857900D0477A /* SPTPersistentCacheOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheOptions.h; sourceTree = "<group>"; };
+		DD1D237C1C77857900D0477A /* SPTPersistentCacheRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheRecord.h; sourceTree = "<group>"; };
+		DD1D237D1C77857900D0477A /* SPTPersistentCacheResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheResponse.h; sourceTree = "<group>"; };
+		DD1D237E1C77857900D0477A /* SPTPersistentCacheTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheTypes.h; sourceTree = "<group>"; };
+		DD1D238C1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+SPTPersistentCacheDomainErrors.h"; sourceTree = "<group>"; };
+		DD1D238D1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SPTPersistentCacheDomainErrors.m"; sourceTree = "<group>"; };
+		DD1D23901C7785A900D0477A /* crc32iso3309.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crc32iso3309.c; sourceTree = "<group>"; };
+		DD1D23911C7785A900D0477A /* crc32iso3309.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc32iso3309.h; sourceTree = "<group>"; };
+		DD1D23921C7785A900D0477A /* SPTPersistentCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCache.m; sourceTree = "<group>"; };
+		DD1D23931C7785A900D0477A /* SPTPersistentCache+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTPersistentCache+Private.h"; sourceTree = "<group>"; };
+		DD1D23941C7785A900D0477A /* SPTPersistentCacheFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheFileManager.h; sourceTree = "<group>"; };
+		DD1D23951C7785A900D0477A /* SPTPersistentCacheFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheFileManager.m; sourceTree = "<group>"; };
+		DD1D23961C7785A900D0477A /* SPTPersistentCacheHeader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheHeader.m; sourceTree = "<group>"; };
+		DD1D23971C7785A900D0477A /* SPTPersistentCacheOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheOptions.m; sourceTree = "<group>"; };
+		DD1D23981C7785A900D0477A /* SPTPersistentCacheRecord.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheRecord.m; sourceTree = "<group>"; };
+		DD1D23991C7785A900D0477A /* SPTPersistentCacheRecord+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTPersistentCacheRecord+Private.h"; sourceTree = "<group>"; };
+		DD1D239A1C7785A900D0477A /* SPTPersistentCacheResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheResponse.m; sourceTree = "<group>"; };
+		DD1D239B1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPTPersistentCacheResponse+Private.h"; sourceTree = "<group>"; };
+		DD1D239C1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheTimerProxy.h; sourceTree = "<group>"; };
+		DD1D239D1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheTimerProxy.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,8 +102,8 @@
 		052021921C737DBD003A4FB4 = {
 			isa = PBXGroup;
 			children = (
-				052021A81C737E1E003A4FB4 /* Public API */,
-				052021B61C737E3E003A4FB4 /* SPTPersistentCache */,
+				052021A81C737E1E003A4FB4 /* API */,
+				052021B61C737E3E003A4FB4 /* Sources */,
 				052021FA1C7382B5003A4FB4 /* Supporting Files */,
 				0520219D1C737DBE003A4FB4 /* Products */,
 			);
@@ -102,38 +118,41 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		052021A81C737E1E003A4FB4 /* Public API */ = {
+		052021A81C737E1E003A4FB4 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				C48AE7B91C76174600814D7D /* SPTPersistentCacheTypes.h */,
-				C48AE7BA1C76174600814D7D /* SPTPersistentCache.h */,
-				C48AE7BB1C76174600814D7D /* SPTPersistentCacheOptions.h */,
-				C48AE7BC1C76174600814D7D /* SPTPersistentCacheHeader.h */,
-				C48AE7BD1C76174600814D7D /* SPTPersistentCacheRecord.h */,
-				C48AE7BE1C76174600814D7D /* SPTPersistentCacheResponse.h */,
+				DD1D23791C77857900D0477A /* SPTPersistentCache.h */,
+				DD1D237A1C77857900D0477A /* SPTPersistentCacheHeader.h */,
+				DD1D237B1C77857900D0477A /* SPTPersistentCacheOptions.h */,
+				DD1D237C1C77857900D0477A /* SPTPersistentCacheRecord.h */,
+				DD1D237D1C77857900D0477A /* SPTPersistentCacheResponse.h */,
+				DD1D237E1C77857900D0477A /* SPTPersistentCacheTypes.h */,
 			);
-			name = "Public API";
+			name = API;
+			path = ../include/SPTPersistentCache;
 			sourceTree = "<group>";
 		};
-		052021B61C737E3E003A4FB4 /* SPTPersistentCache */ = {
+		052021B61C737E3E003A4FB4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				052021B71C737E66003A4FB4 /* crc32iso3309.c */,
-				052021B81C737E66003A4FB4 /* crc32iso3309.h */,
-				052021B91C737E66003A4FB4 /* SPTPersistentCacheResponse.m */,
-				052021BA1C737E66003A4FB4 /* SPTPersistentCacheResponse+Private.h */,
-				052021BB1C737E66003A4FB4 /* SPTPersistentCache.m */,
-				052021BC1C737E66003A4FB4 /* SPTPersistentCache+Private.h */,
-				052021BD1C737E66003A4FB4 /* SPTPersistentCacheHeader.m */,
-				052021BE1C737E66003A4FB4 /* SPTPersistentCacheOptions.m */,
-				052021BF1C737E66003A4FB4 /* SPTPersistentCacheRecord.m */,
-				052021C01C737E66003A4FB4 /* SPTPersistentCacheRecord+Private.h */,
-				052021C11C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.h */,
-				052021C21C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m */,
-				052021CF1C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.h */,
-				052021D01C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m */,
+				DD1D238B1C7785A900D0477A /* Categories */,
+				DD1D23901C7785A900D0477A /* crc32iso3309.c */,
+				DD1D23911C7785A900D0477A /* crc32iso3309.h */,
+				DD1D23921C7785A900D0477A /* SPTPersistentCache.m */,
+				DD1D23931C7785A900D0477A /* SPTPersistentCache+Private.h */,
+				DD1D23941C7785A900D0477A /* SPTPersistentCacheFileManager.h */,
+				DD1D23951C7785A900D0477A /* SPTPersistentCacheFileManager.m */,
+				DD1D23961C7785A900D0477A /* SPTPersistentCacheHeader.m */,
+				DD1D23971C7785A900D0477A /* SPTPersistentCacheOptions.m */,
+				DD1D23981C7785A900D0477A /* SPTPersistentCacheRecord.m */,
+				DD1D23991C7785A900D0477A /* SPTPersistentCacheRecord+Private.h */,
+				DD1D239A1C7785A900D0477A /* SPTPersistentCacheResponse.m */,
+				DD1D239B1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h */,
+				DD1D239C1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h */,
+				DD1D239D1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m */,
 			);
-			name = SPTPersistentCache;
+			name = Sources;
+			path = ../Sources;
 			sourceTree = "<group>";
 		};
 		052021FA1C7382B5003A4FB4 /* Supporting Files */ = {
@@ -146,6 +165,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		DD1D238B1C7785A900D0477A /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				DD1D238C1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.h */,
+				DD1D238D1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -153,18 +181,19 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				052021C81C737E66003A4FB4 /* SPTPersistentCache+Private.h in Headers */,
-				C48AE7C21C76174600814D7D /* SPTPersistentCacheHeader.h in Headers */,
-				C48AE7C31C76174600814D7D /* SPTPersistentCacheRecord.h in Headers */,
-				052021D11C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.h in Headers */,
-				C48AE7BF1C76174600814D7D /* SPTPersistentCacheTypes.h in Headers */,
-				052021CC1C737E66003A4FB4 /* SPTPersistentCacheRecord+Private.h in Headers */,
-				052021C41C737E66003A4FB4 /* crc32iso3309.h in Headers */,
-				052021CD1C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.h in Headers */,
-				C48AE7C01C76174600814D7D /* SPTPersistentCache.h in Headers */,
-				C48AE7C41C76174600814D7D /* SPTPersistentCacheResponse.h in Headers */,
-				C48AE7C11C76174600814D7D /* SPTPersistentCacheOptions.h in Headers */,
-				052021C61C737E66003A4FB4 /* SPTPersistentCacheResponse+Private.h in Headers */,
+				DD1D239E1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.h in Headers */,
+				DD1D23AB1C7785A900D0477A /* SPTPersistentCacheRecord+Private.h in Headers */,
+				DD1D23841C77857900D0477A /* SPTPersistentCacheTypes.h in Headers */,
+				DD1D23A61C7785A900D0477A /* SPTPersistentCacheFileManager.h in Headers */,
+				DD1D23831C77857900D0477A /* SPTPersistentCacheResponse.h in Headers */,
+				DD1D237F1C77857900D0477A /* SPTPersistentCache.h in Headers */,
+				DD1D23801C77857900D0477A /* SPTPersistentCacheHeader.h in Headers */,
+				DD1D23AD1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h in Headers */,
+				DD1D23821C77857900D0477A /* SPTPersistentCacheRecord.h in Headers */,
+				DD1D23A31C7785A900D0477A /* crc32iso3309.h in Headers */,
+				DD1D23AE1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h in Headers */,
+				DD1D23A51C7785A900D0477A /* SPTPersistentCache+Private.h in Headers */,
+				DD1D23811C77857900D0477A /* SPTPersistentCacheOptions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +201,18 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD1D23BE1C7785AE00D0477A /* SPTPersistentCacheTimerProxy.h in Headers */,
+				DD1D238A1C77857E00D0477A /* SPTPersistentCacheTypes.h in Headers */,
+				DD1D23B61C7785AE00D0477A /* SPTPersistentCacheFileManager.h in Headers */,
+				DD1D23851C77857E00D0477A /* SPTPersistentCache.h in Headers */,
+				DD1D23B51C7785AE00D0477A /* SPTPersistentCache+Private.h in Headers */,
+				DD1D23BB1C7785AE00D0477A /* SPTPersistentCacheRecord+Private.h in Headers */,
+				DD1D23B31C7785AE00D0477A /* crc32iso3309.h in Headers */,
+				DD1D23BD1C7785AE00D0477A /* SPTPersistentCacheResponse+Private.h in Headers */,
+				DD1D23871C77857E00D0477A /* SPTPersistentCacheOptions.h in Headers */,
+				DD1D23891C77857E00D0477A /* SPTPersistentCacheResponse.h in Headers */,
+				DD1D23861C77857E00D0477A /* SPTPersistentCacheHeader.h in Headers */,
+				DD1D23881C77857E00D0477A /* SPTPersistentCacheRecord.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,14 +313,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				052021D21C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m in Sources */,
-				052021C91C737E66003A4FB4 /* SPTPersistentCacheHeader.m in Sources */,
-				052021C51C737E66003A4FB4 /* SPTPersistentCacheResponse.m in Sources */,
-				052021C71C737E66003A4FB4 /* SPTPersistentCache.m in Sources */,
-				052021CE1C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m in Sources */,
-				052021C31C737E66003A4FB4 /* crc32iso3309.c in Sources */,
-				052021CB1C737E66003A4FB4 /* SPTPersistentCacheRecord.m in Sources */,
-				052021CA1C737E66003A4FB4 /* SPTPersistentCacheOptions.m in Sources */,
+				DD1D23AA1C7785A900D0477A /* SPTPersistentCacheRecord.m in Sources */,
+				DD1D23A21C7785A900D0477A /* crc32iso3309.c in Sources */,
+				DD1D23AF1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m in Sources */,
+				DD1D23A71C7785A900D0477A /* SPTPersistentCacheFileManager.m in Sources */,
+				DD1D239F1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m in Sources */,
+				DD1D23A81C7785A900D0477A /* SPTPersistentCacheHeader.m in Sources */,
+				DD1D23A41C7785A900D0477A /* SPTPersistentCache.m in Sources */,
+				DD1D23AC1C7785A900D0477A /* SPTPersistentCacheResponse.m in Sources */,
+				DD1D23A91C7785A900D0477A /* SPTPersistentCacheOptions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -287,14 +329,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				052021FE1C738392003A4FB4 /* crc32iso3309.c in Sources */,
-				052021FF1C738392003A4FB4 /* SPTPersistentCacheResponse.m in Sources */,
-				052022001C738392003A4FB4 /* SPTPersistentCache.m in Sources */,
-				052022011C738392003A4FB4 /* SPTPersistentCacheHeader.m in Sources */,
-				052022021C738392003A4FB4 /* SPTPersistentCacheOptions.m in Sources */,
-				052022031C738392003A4FB4 /* SPTPersistentCacheRecord.m in Sources */,
-				052022041C738392003A4FB4 /* SPTPersistentCacheTimerProxy.m in Sources */,
-				052022051C738392003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m in Sources */,
+				DD1D23BF1C7785AE00D0477A /* SPTPersistentCacheTimerProxy.m in Sources */,
+				DD1D23B21C7785AE00D0477A /* crc32iso3309.c in Sources */,
+				DD1D23B81C7785AE00D0477A /* SPTPersistentCacheHeader.m in Sources */,
+				DD1D23BC1C7785AE00D0477A /* SPTPersistentCacheResponse.m in Sources */,
+				DD1D23BA1C7785AE00D0477A /* SPTPersistentCacheRecord.m in Sources */,
+				DD1D23B71C7785AE00D0477A /* SPTPersistentCacheFileManager.m in Sources */,
+				DD1D23B91C7785AE00D0477A /* SPTPersistentCacheOptions.m in Sources */,
+				DD1D23B41C7785AE00D0477A /* SPTPersistentCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0520219C1C737DBE003A4FB4 /* SPTPersistentCacheFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTPersistentCacheFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0520219C1C737DBE003A4FB4 /* SPTPersistentCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTPersistentCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		052021B71C737E66003A4FB4 /* crc32iso3309.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = crc32iso3309.c; path = ../Sources/crc32iso3309.c; sourceTree = "<group>"; };
 		052021B81C737E66003A4FB4 /* crc32iso3309.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc32iso3309.h; path = ../Sources/crc32iso3309.h; sourceTree = "<group>"; };
 		052021B91C737E66003A4FB4 /* SPTPersistentCacheResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheResponse.m; path = ../Sources/SPTPersistentCacheResponse.m; sourceTree = "<group>"; };
@@ -53,7 +53,7 @@
 		052021C21C737E66003A4FB4 /* SPTPersistentCacheTimerProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTPersistentCacheTimerProxy.m; path = ../Sources/SPTPersistentCacheTimerProxy.m; sourceTree = "<group>"; };
 		052021CF1C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SPTPersistentCacheDomainErrors.h"; path = "../Sources/Categories/NSError+SPTPersistentCacheDomainErrors.h"; sourceTree = "<group>"; };
 		052021D01C737E6E003A4FB4 /* NSError+SPTPersistentCacheDomainErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SPTPersistentCacheDomainErrors.m"; path = "../Sources/Categories/NSError+SPTPersistentCacheDomainErrors.m"; sourceTree = "<group>"; };
-		052021F21C738048003A4FB4 /* SPTPersistentCacheOSXFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTPersistentCacheOSXFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		052021F21C738048003A4FB4 /* SPTPersistentCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SPTPersistentCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		052021FB1C7382C6003A4FB4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		052022061C738600003A4FB4 /* project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = project.xcconfig; path = ../project.xcconfig; sourceTree = "<group>"; };
 		052022091C738637003A4FB4 /* spotify_os.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = spotify_os.xcconfig; path = ../spotify_os.xcconfig; sourceTree = "<group>"; };
@@ -96,8 +96,8 @@
 		0520219D1C737DBE003A4FB4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0520219C1C737DBE003A4FB4 /* SPTPersistentCacheFramework.framework */,
-				052021F21C738048003A4FB4 /* SPTPersistentCacheOSXFramework.framework */,
+				0520219C1C737DBE003A4FB4 /* SPTPersistentCache.framework */,
+				052021F21C738048003A4FB4 /* SPTPersistentCache.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -178,9 +178,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		0520219B1C737DBE003A4FB4 /* SPTPersistentCacheFramework */ = {
+		0520219B1C737DBE003A4FB4 /* SPTPersistentCache-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 052021A41C737DBE003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCacheFramework" */;
+			buildConfigurationList = 052021A41C737DBE003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCache-iOS" */;
 			buildPhases = (
 				052021971C737DBE003A4FB4 /* Sources */,
 				052021981C737DBE003A4FB4 /* Frameworks */,
@@ -191,14 +191,14 @@
 			);
 			dependencies = (
 			);
-			name = SPTPersistentCacheFramework;
+			name = "SPTPersistentCache-iOS";
 			productName = SPTPersistentCacheFramework;
-			productReference = 0520219C1C737DBE003A4FB4 /* SPTPersistentCacheFramework.framework */;
+			productReference = 0520219C1C737DBE003A4FB4 /* SPTPersistentCache.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		052021F11C738048003A4FB4 /* SPTPersistentCacheOSXFramework */ = {
+		052021F11C738048003A4FB4 /* SPTPersistentCache-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 052021F71C738048003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCacheOSXFramework" */;
+			buildConfigurationList = 052021F71C738048003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCache-OSX" */;
 			buildPhases = (
 				052021ED1C738048003A4FB4 /* Sources */,
 				052021EE1C738048003A4FB4 /* Frameworks */,
@@ -209,9 +209,9 @@
 			);
 			dependencies = (
 			);
-			name = SPTPersistentCacheOSXFramework;
+			name = "SPTPersistentCache-OSX";
 			productName = SPTPersistentCacheOSXFramework;
-			productReference = 052021F21C738048003A4FB4 /* SPTPersistentCacheOSXFramework.framework */;
+			productReference = 052021F21C738048003A4FB4 /* SPTPersistentCache.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -244,8 +244,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				0520219B1C737DBE003A4FB4 /* SPTPersistentCacheFramework */,
-				052021F11C738048003A4FB4 /* SPTPersistentCacheOSXFramework */,
+				0520219B1C737DBE003A4FB4 /* SPTPersistentCache-iOS */,
+				052021F11C738048003A4FB4 /* SPTPersistentCache-OSX */,
 			);
 		};
 /* End PBXProject section */
@@ -305,12 +305,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 052022061C738600003A4FB4 /* project.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				COPY_PHASE_STRIP = NO;
 				HEADER_SEARCH_PATHS = ../include;
 				INFOPLIST_FILE = Info.plist;
-				MODULEMAP_FILE = ../include/SPTPersistentCache/module.modulemap;
 			};
 			name = Debug;
 		};
@@ -318,12 +314,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 052022061C738600003A4FB4 /* project.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				COPY_PHASE_STRIP = NO;
 				HEADER_SEARCH_PATHS = ../include;
 				INFOPLIST_FILE = Info.plist;
-				MODULEMAP_FILE = ../include/SPTPersistentCache/module.modulemap;
 			};
 			name = Release;
 		};
@@ -331,13 +323,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEFINES_MODULE = YES;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = ../include/SPTPersistentCache/module.modulemap;
-				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.SPTPersistentCacheiOSFramework;
-				PRODUCT_NAME = SPTPersistentCacheFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-iOS";
+				PRODUCT_NAME = SPTPersistentCache;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -346,13 +334,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEFINES_MODULE = YES;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = ../include/SPTPersistentCache/module.modulemap;
-				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.SPTPersistentCacheiOSFramework;
-				PRODUCT_NAME = SPTPersistentCacheFramework;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-iOS";
+				PRODUCT_NAME = SPTPersistentCache;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -367,11 +351,8 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.SPTPersistentCacheOSXFramework;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-OSX";
+				PRODUCT_NAME = SPTPersistentCache;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -387,11 +368,8 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.SPTPersistentCacheOSXFramework;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-OSX";
+				PRODUCT_NAME = SPTPersistentCache;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -409,7 +387,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		052021A41C737DBE003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCacheFramework" */ = {
+		052021A41C737DBE003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCache-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				052021A51C737DBE003A4FB4 /* Debug */,
@@ -418,7 +396,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		052021F71C738048003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCacheOSXFramework" */ = {
+		052021F71C738048003A4FB4 /* Build configuration list for PBXNativeTarget "SPTPersistentCache-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				052021F81C738048003A4FB4 /* Debug */,

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-OSX.xcscheme
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-OSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "052021F11C738048003A4FB4"
+               BuildableName = "SPTPersistentCache.framework"
+               BlueprintName = "SPTPersistentCache-OSX"
+               ReferencedContainer = "container:SPTPersistentCacheFramework.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "052021F11C738048003A4FB4"
+            BuildableName = "SPTPersistentCache.framework"
+            BlueprintName = "SPTPersistentCache-OSX"
+            ReferencedContainer = "container:SPTPersistentCacheFramework.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "052021F11C738048003A4FB4"
+            BuildableName = "SPTPersistentCache.framework"
+            BlueprintName = "SPTPersistentCache-OSX"
+            ReferencedContainer = "container:SPTPersistentCacheFramework.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-iOS.xcscheme
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0520219B1C737DBE003A4FB4"
+               BuildableName = "SPTPersistentCache.framework"
+               BlueprintName = "SPTPersistentCache-iOS"
+               ReferencedContainer = "container:SPTPersistentCacheFramework.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0520219B1C737DBE003A4FB4"
+            BuildableName = "SPTPersistentCache.framework"
+            BlueprintName = "SPTPersistentCache-iOS"
+            ReferencedContainer = "container:SPTPersistentCacheFramework.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0520219B1C737DBE003A4FB4"
+            BuildableName = "SPTPersistentCache.framework"
+            BlueprintName = "SPTPersistentCache-iOS"
+            ReferencedContainer = "container:SPTPersistentCacheFramework.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,20 +11,14 @@ travis_fold_close "License conformance"
 
 # Executing build actions
 echo "Executing build actions: $BUILD_ACTIONS"
-retry_attempts=0
-until [ $retry_attempts -ge 2 ]
-do
-    xcrun xcodebuild $BUILD_ACTIONS \
-        NSUnbufferedIO=YES \
-        -project "$PROJECT" \
-        -scheme "$SCHEME" \
-        -sdk "$TEST_SDK" \
-        -destination "$TEST_DEST" \
-        $EXTRA_ARGUMENTS \
-            | xcpretty -c -f `xcpretty-travis-formatter` && break
-    retry_attempts=$[$retry_attempts+1]
-    sleep $retry_attempts
-done
+xcrun xcodebuild $BUILD_ACTIONS \
+   NSUnbufferedIO=YES \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -sdk "$TEST_SDK" \
+    -destination "$TEST_DEST" \
+    $EXTRA_ARGUMENTS \
+        | xcpretty -c -f `xcpretty-travis-formatter`
 
 # Linting
 travis_fold_open "Linting" "Linting CocoaPods specification…"


### PR DESCRIPTION
We were still overriding some settings defined in the shared xcconfig in the Xcode projects. Also some targets where incorrectly named. Last I added the missing Xcode schemes and made sure the Travis-CI config points to the real Xcode projects.

@8W9aG @dflems 
