### PR TITLE
Love to SPTPersistentCacheRecordHeaderType 

### DIFF
--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		C413BA011C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */; };
 		C413BA051C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA041C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m */; };
 		C413BA071C71E2DC002D41FB /* NSError+SPTPersistentCacheDomainErrorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA061C71E2DC002D41FB /* NSError+SPTPersistentCacheDomainErrorsTests.m */; };
+		C45526AF1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C45526AE1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.m */; };
 		C48AE4641C74A7F800814D7D /* SPTPersistentCacheFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C48AE4631C74A7F800814D7D /* SPTPersistentCacheFileManager.m */; };
 		C48AE7411C75BB8300814D7D /* SPTPersistentCacheFileManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C48AE7401C75BB8300814D7D /* SPTPersistentCacheFileManagerTests.m */; };
 		C4B4148F1C6A1BED0099FECD /* SPTPersistentCacheResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C4B4148E1C6A1BED0099FECD /* SPTPersistentCacheResponseTests.m */; };
@@ -116,6 +117,8 @@
 		C413BA031C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SPTPersistentCacheDomainErrors.h"; path = "Categories/NSError+SPTPersistentCacheDomainErrors.h"; sourceTree = "<group>"; };
 		C413BA041C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SPTPersistentCacheDomainErrors.m"; path = "Categories/NSError+SPTPersistentCacheDomainErrors.m"; sourceTree = "<group>"; };
 		C413BA061C71E2DC002D41FB /* NSError+SPTPersistentCacheDomainErrorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SPTPersistentCacheDomainErrorsTests.m"; sourceTree = "<group>"; };
+		C45526AD1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheTypeUtilities.h; sourceTree = "<group>"; };
+		C45526AE1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheTypeUtilities.m; sourceTree = "<group>"; };
 		C48AE4621C74A7F800814D7D /* SPTPersistentCacheFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheFileManager.h; sourceTree = "<group>"; };
 		C48AE4631C74A7F800814D7D /* SPTPersistentCacheFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheFileManager.m; sourceTree = "<group>"; };
 		C48AE7401C75BB8300814D7D /* SPTPersistentCacheFileManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheFileManagerTests.m; sourceTree = "<group>"; };
@@ -227,6 +230,8 @@
 				057AFD5A1C70F99A00350C9F /* SPTPersistentCacheHeader.m */,
 				C48AE4621C74A7F800814D7D /* SPTPersistentCacheFileManager.h */,
 				C48AE4631C74A7F800814D7D /* SPTPersistentCacheFileManager.m */,
+				C45526AD1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.h */,
+				C45526AE1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -391,6 +396,7 @@
 				0595F0A91C5008060052328B /* SPTPersistentCacheRecord.m in Sources */,
 				057AFD5B1C70F99A00350C9F /* SPTPersistentCacheHeader.m in Sources */,
 				696CD78A1C4707E20071DD18 /* crc32iso3309.c in Sources */,
+				C45526AF1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */,
 				696CD78B1C4707E20071DD18 /* SPTPersistentCache.m in Sources */,
 				0595F0B01C5009800052328B /* SPTPersistentCacheResponse.m in Sources */,
 				696CD78C1C4707E20071DD18 /* SPTPersistentCacheOptions.m in Sources */,

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C45526B41C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */; };
+		C45526B51C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */; };
+		C45526B61C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C45526B31C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m */; };
+		C45526B71C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C45526B31C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m */; };
 		DD1D237F1C77857900D0477A /* SPTPersistentCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D23791C77857900D0477A /* SPTPersistentCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1D23801C77857900D0477A /* SPTPersistentCacheHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237A1C77857900D0477A /* SPTPersistentCacheHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1D23811C77857900D0477A /* SPTPersistentCacheOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D237B1C77857900D0477A /* SPTPersistentCacheOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -57,6 +61,8 @@
 		052021FB1C7382C6003A4FB4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		052022061C738600003A4FB4 /* project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = project.xcconfig; path = ../project.xcconfig; sourceTree = "<group>"; };
 		052022091C738637003A4FB4 /* spotify_os.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = spotify_os.xcconfig; path = ../spotify_os.xcconfig; sourceTree = "<group>"; };
+		C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheTypeUtilities.h; sourceTree = "<group>"; };
+		C45526B31C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheTypeUtilities.m; sourceTree = "<group>"; };
 		DD1D23791C77857900D0477A /* SPTPersistentCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCache.h; sourceTree = "<group>"; };
 		DD1D237A1C77857900D0477A /* SPTPersistentCacheHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheHeader.h; sourceTree = "<group>"; };
 		DD1D237B1C77857900D0477A /* SPTPersistentCacheOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheOptions.h; sourceTree = "<group>"; };
@@ -150,6 +156,8 @@
 				DD1D239B1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h */,
 				DD1D239C1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h */,
 				DD1D239D1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m */,
+				C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */,
+				C45526B31C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m */,
 			);
 			name = Sources;
 			path = ../Sources;
@@ -186,6 +194,7 @@
 				DD1D23841C77857900D0477A /* SPTPersistentCacheTypes.h in Headers */,
 				DD1D23A61C7785A900D0477A /* SPTPersistentCacheFileManager.h in Headers */,
 				DD1D23831C77857900D0477A /* SPTPersistentCacheResponse.h in Headers */,
+				C45526B41C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */,
 				DD1D237F1C77857900D0477A /* SPTPersistentCache.h in Headers */,
 				DD1D23801C77857900D0477A /* SPTPersistentCacheHeader.h in Headers */,
 				DD1D23AD1C7785A900D0477A /* SPTPersistentCacheResponse+Private.h in Headers */,
@@ -211,6 +220,7 @@
 				DD1D23BD1C7785AE00D0477A /* SPTPersistentCacheResponse+Private.h in Headers */,
 				DD1D23871C77857E00D0477A /* SPTPersistentCacheOptions.h in Headers */,
 				DD1D23891C77857E00D0477A /* SPTPersistentCacheResponse.h in Headers */,
+				C45526B51C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */,
 				DD1D23861C77857E00D0477A /* SPTPersistentCacheHeader.h in Headers */,
 				DD1D23881C77857E00D0477A /* SPTPersistentCacheRecord.h in Headers */,
 			);
@@ -319,6 +329,7 @@
 				DD1D23A71C7785A900D0477A /* SPTPersistentCacheFileManager.m in Sources */,
 				DD1D239F1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m in Sources */,
 				DD1D23A81C7785A900D0477A /* SPTPersistentCacheHeader.m in Sources */,
+				C45526B61C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */,
 				DD1D23A41C7785A900D0477A /* SPTPersistentCache.m in Sources */,
 				DD1D23AC1C7785A900D0477A /* SPTPersistentCacheResponse.m in Sources */,
 				DD1D23A91C7785A900D0477A /* SPTPersistentCacheOptions.m in Sources */,
@@ -337,6 +348,7 @@
 				DD1D23B71C7785AE00D0477A /* SPTPersistentCacheFileManager.m in Sources */,
 				DD1D23B91C7785AE00D0477A /* SPTPersistentCacheOptions.m in Sources */,
 				DD1D23B41C7785AE00D0477A /* SPTPersistentCache.m in Sources */,
+				C45526B71C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -30,20 +30,11 @@
 #import "NSError+SPTPersistentCacheDomainErrors.h"
 #import "SPTPersistentCacheFileManager.h"
 #include <sys/stat.h>
+#import "SPTPersistentCacheTypeUtilities.h"
+
 
 // Enable for more precise logging
 //#define DEBUG_OUTPUT_ENABLED
-
-/**
- * Converts the given `double` _value_ to an `uint64_t` value.
- *
- * @param value The value as a `double`.
- * @return The value as an `uint64_t`.
- */
-uint64_t spt_uint64rint(double value)
-{
-    return (uint64_t)llrint(value);
-}
 
 NSString *const SPTPersistentCacheErrorDomain = @"persistent.cache.error";
 static const uint64_t kTTLUpperBoundInSec = 86400 * 31 * 2;

--- a/Sources/SPTPersistentCacheHeader.m
+++ b/Sources/SPTPersistentCacheHeader.m
@@ -40,6 +40,26 @@ NS_INLINE BOOL SPTPersistentCachePointerMagicAlignCheck(const void *ptr)
     return (v % align == 0);
 }
 
+SPTPersistentCacheRecordHeaderType SPTPersistentCacheRecordHeaderTypeMake(uint64_t ttl,
+                                                                          uint64_t payloadSize,
+                                                                          uint64_t updateTime,
+                                                                          BOOL isLocked)
+{
+    SPTPersistentCacheRecordHeaderType dummy;
+    memset(&dummy, 0, SPTPersistentCacheRecordHeaderSize);
+    SPTPersistentCacheRecordHeaderType *header = &dummy;
+    
+    header->magic = SPTPersistentCacheMagicValue;
+    header->headerSize = (uint32_t)SPTPersistentCacheRecordHeaderSize;
+    header->refCount = (isLocked ? 1 : 0);
+    header->ttl = ttl;
+    header->payloadSizeBytes = payloadSize;
+    header->updateTimeSec = updateTime;
+    header->crc = SPTPersistentCacheCalculateHeaderCRC(header);
+    
+    return dummy;
+}
+
 SPTPersistentCacheRecordHeaderType *SPTPersistentCacheGetHeaderFromData(void *data, size_t size)
 {
     if (size < SPTPersistentCacheRecordHeaderSize) {

--- a/Sources/SPTPersistentCacheHeader.m
+++ b/Sources/SPTPersistentCacheHeader.m
@@ -26,11 +26,11 @@
 #include "crc32iso3309.h"
 
 const SPTPersistentCacheMagicType SPTPersistentCacheMagicValue = 0x46545053; // SPTF
-const size_t SPTPersistentCacheRecordHeaderSize = sizeof(SPTPersistentCacheRecordHeaderType);
+const size_t SPTPersistentCacheRecordHeaderSize = sizeof(SPTPersistentCacheRecordHeader);
 
-_Static_assert(sizeof(SPTPersistentCacheRecordHeaderType) == 64,
-               "Struct SPTPersistentCacheRecordHeaderType has to be packed without padding");
-_Static_assert(sizeof(SPTPersistentCacheRecordHeaderType) % 4 == 0,
+_Static_assert(sizeof(SPTPersistentCacheRecordHeader) == 64,
+               "Struct SPTPersistentCacheRecordHeader has to be packed without padding");
+_Static_assert(sizeof(SPTPersistentCacheRecordHeader) % 4 == 0,
                "Struct size has to be multiple of 4");
 
 NS_INLINE BOOL SPTPersistentCachePointerMagicAlignCheck(const void *ptr)
@@ -40,14 +40,15 @@ NS_INLINE BOOL SPTPersistentCachePointerMagicAlignCheck(const void *ptr)
     return (v % align == 0);
 }
 
-SPTPersistentCacheRecordHeaderType SPTPersistentCacheRecordHeaderTypeMake(uint64_t ttl,
-                                                                          uint64_t payloadSize,
-                                                                          uint64_t updateTime,
-                                                                          BOOL isLocked)
+SPTPersistentCacheRecordHeader SPTPersistentCacheRecordHeaderMake(uint64_t ttl,
+                                                                  uint64_t payloadSize,
+                                                                  uint64_t updateTime,
+                                                                  BOOL isLocked)
+
 {
-    SPTPersistentCacheRecordHeaderType dummy;
+    SPTPersistentCacheRecordHeader dummy;
     memset(&dummy, 0, SPTPersistentCacheRecordHeaderSize);
-    SPTPersistentCacheRecordHeaderType *header = &dummy;
+    SPTPersistentCacheRecordHeader *header = &dummy;
     
     header->magic = SPTPersistentCacheMagicValue;
     header->headerSize = (uint32_t)SPTPersistentCacheRecordHeaderSize;
@@ -60,16 +61,16 @@ SPTPersistentCacheRecordHeaderType SPTPersistentCacheRecordHeaderTypeMake(uint64
     return dummy;
 }
 
-SPTPersistentCacheRecordHeaderType *SPTPersistentCacheGetHeaderFromData(void *data, size_t size)
+SPTPersistentCacheRecordHeader *SPTPersistentCacheGetHeaderFromData(void *data, size_t size)
 {
     if (size < SPTPersistentCacheRecordHeaderSize) {
         return NULL;
     }
 
-    return (SPTPersistentCacheRecordHeaderType *)data;
+    return (SPTPersistentCacheRecordHeader *)data;
 }
 
-int /*SPTPersistentCacheLoadingError*/ SPTPersistentCacheValidateHeader(const SPTPersistentCacheRecordHeaderType *header)
+int /*SPTPersistentCacheLoadingError*/ SPTPersistentCacheValidateHeader(const SPTPersistentCacheRecordHeader *header)
 {
     if (header == NULL) {
         return SPTPersistentCacheLoadingErrorInternalInconsistency;
@@ -99,7 +100,7 @@ int /*SPTPersistentCacheLoadingError*/ SPTPersistentCacheValidateHeader(const SP
     return -1;
 }
 
-NSError * SPTPersistentCacheCheckValidHeader(SPTPersistentCacheRecordHeaderType *header)
+NSError * SPTPersistentCacheCheckValidHeader(SPTPersistentCacheRecordHeader *header)
 {
     int code = SPTPersistentCacheValidateHeader(header);
     if (code == -1) { // No error
@@ -109,7 +110,7 @@ NSError * SPTPersistentCacheCheckValidHeader(SPTPersistentCacheRecordHeaderType 
     return [NSError spt_persistentDataCacheErrorWithCode:code];
 }
 
-uint32_t SPTPersistentCacheCalculateHeaderCRC(const SPTPersistentCacheRecordHeaderType *header)
+uint32_t SPTPersistentCacheCalculateHeaderCRC(const SPTPersistentCacheRecordHeader *header)
 {
     if (header == NULL) {
         return 0;

--- a/Sources/SPTPersistentCacheTypeUtilities.h
+++ b/Sources/SPTPersistentCacheTypeUtilities.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+
+/**
+ * Converts the given `double` _value_ to an `uint64_t` value.
+ *
+ * @param value The value as a `double`.
+ * @return The value as an `uint64_t`.
+ */
+uint64_t spt_uint64rint(double value);

--- a/Sources/SPTPersistentCacheTypeUtilities.m
+++ b/Sources/SPTPersistentCacheTypeUtilities.m
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#import "SPTPersistentCacheTypeUtilities.h"
+
+
+uint64_t spt_uint64rint(double value)
+{
+    return (uint64_t)llrint(value);
+}

--- a/Tests/SPTPersistentCacheHeaderTests.m
+++ b/Tests/SPTPersistentCacheHeaderTests.m
@@ -50,7 +50,7 @@
     free(data);
 }
 
-- (void)testSPTPersistentCacheRecordHeaderTypeMake
+- (void)testSPTPersistentCacheRecordHeaderMake
 {
     uint64_t ttl = 64;
     uint64_t payloadSize = 400;
@@ -58,9 +58,10 @@
     BOOL isLocked = YES;
     
     
-    SPTPersistentCacheRecordHeaderType header = SPTPersistentCacheRecordHeaderTypeMake(ttl,
-                                                                                       payloadSize, updateTime,
-                                                                                       isLocked);
+    SPTPersistentCacheRecordHeader header = SPTPersistentCacheRecordHeaderMake(ttl,
+                                                                               payloadSize,
+                                                                               updateTime,
+                                                                               isLocked);
     
     XCTAssertEqual(header.reserved1, (uint64_t)0);
     XCTAssertEqual(header.reserved2, (uint64_t)0);

--- a/Tests/SPTPersistentCacheHeaderTests.m
+++ b/Tests/SPTPersistentCacheHeaderTests.m
@@ -22,6 +22,7 @@
 
 #import "SPTPersistentCacheHeader.h"
 #import <SPTPersistentCache/SPTPersistentCache.h>
+#import "SPTPersistentCacheTypeUtilities.h"
 
 
 @interface SPTPersistentCacheHeaderTests : XCTestCase

--- a/Tests/SPTPersistentCacheHeaderTests.m
+++ b/Tests/SPTPersistentCacheHeaderTests.m
@@ -21,6 +21,8 @@
 #import <XCTest/XCTest.h>
 
 #import "SPTPersistentCacheHeader.h"
+#import <SPTPersistentCache/SPTPersistentCache.h>
+
 
 @interface SPTPersistentCacheHeaderTests : XCTestCase
 
@@ -46,6 +48,32 @@
     XCTAssertEqual(SPTPersistentCacheGetHeaderFromData(data, rightHeaderSize), data);
     
     free(data);
+}
+
+- (void)testSPTPersistentCacheRecordHeaderTypeMake
+{
+    uint64_t ttl = 64;
+    uint64_t payloadSize = 400;
+    uint64_t updateTime = spt_uint64rint([[NSDate date] timeIntervalSince1970]);
+    BOOL isLocked = YES;
+    
+    
+    SPTPersistentCacheRecordHeaderType header = SPTPersistentCacheRecordHeaderTypeMake(ttl,
+                                                                                       payloadSize, updateTime,
+                                                                                       isLocked);
+    
+    XCTAssertEqual(header.reserved1, (uint64_t)0);
+    XCTAssertEqual(header.reserved2, (uint64_t)0);
+    XCTAssertEqual(header.reserved3, (uint64_t)0);
+    XCTAssertEqual(header.reserved4, (uint64_t)0);
+    XCTAssertEqual(header.flags, (uint32_t)0);
+    XCTAssertEqual(header.magic, SPTPersistentCacheMagicValue);
+    XCTAssertEqual(header.headerSize, (uint32_t)SPTPersistentCacheRecordHeaderSize);
+    XCTAssertEqual(!!header.refCount, isLocked);
+    XCTAssertEqual(header.ttl, ttl);
+    XCTAssertEqual(header.payloadSizeBytes, payloadSize);
+    XCTAssertEqual(header.updateTimeSec, updateTime);
+    XCTAssertEqual(header.crc, SPTPersistentCacheCalculateHeaderCRC(&header));
 }
 
 @end

--- a/Tests/SPTPersistentCacheTests.m
+++ b/Tests/SPTPersistentCacheTests.m
@@ -105,7 +105,7 @@ static NSUInteger params_GetFilesNumber(BOOL locked);
 static NSUInteger params_GetCorruptedFilesNumber(void);
 static NSUInteger params_GetDefaultExpireFilesNumber(void);
 
-static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersistentCacheRecordHeaderType *header);
+static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersistentCacheRecordHeader *header);
 
 @interface SPTPersistentCache (Testing)
 - (void)runRegularGC;
@@ -1121,7 +1121,7 @@ static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersi
     for (unsigned i = 0; i < count; ++i) {
         NSString *path = [fileManager pathForKey:self.imageNames[i]];
 
-        SPTPersistentCacheRecordHeaderType header;
+        SPTPersistentCacheRecordHeader header;
         BOOL opened = spt_test_ReadHeaderForFile(path.UTF8String, YES, &header);
         if (kParams[i].locked) {
             ++lockedCount;
@@ -1158,7 +1158,7 @@ static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersi
     for (unsigned i = 0; i < count; ++i) {
         NSString *path = [fileManager pathForKey:self.imageNames[i]];
 
-        SPTPersistentCacheRecordHeaderType header;
+        SPTPersistentCacheRecordHeader header;
         BOOL opened = spt_test_ReadHeaderForFile(path.UTF8String, YES, &header);
         if (kParams[i].locked) {
             ++lockedCount;
@@ -1238,7 +1238,7 @@ static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersi
         }
 
         NSString *path = [fileManager pathForKey:savedItems[i]];
-        SPTPersistentCacheRecordHeaderType header;
+        SPTPersistentCacheRecordHeader header;
         BOOL opened = spt_test_ReadHeaderForFile(path.UTF8String, YES, &header);
         XCTAssertTrue(opened, @"Saved files expected to in place");
     }
@@ -1279,7 +1279,7 @@ static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersi
     [self waitForExpectationsWithTimeout:kDefaultWaitTime handler:nil];
 
     // Check data
-    SPTPersistentCacheRecordHeaderType header;
+    SPTPersistentCacheRecordHeader header;
     XCTAssertTrue(spt_test_ReadHeaderForFile(path.UTF8String, YES, &header), @"Expect valid record");
     XCTAssertEqual(header.ttl, kTTL1, @"TTL must match");
     XCTAssertEqual(header.refCount, 1u, @"refCount must match");
@@ -1354,7 +1354,7 @@ SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader,
         return;
     }
 
-    SPTPersistentCacheRecordHeaderType header;
+    SPTPersistentCacheRecordHeader header;
     memset(&header, 0, (size_t)SPTPersistentCacheRecordHeaderSize);
 
     if (pdcError != SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader) {
@@ -1414,7 +1414,7 @@ SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader,
         return;
     }
 
-    SPTPersistentCacheRecordHeaderType header;
+    SPTPersistentCacheRecordHeader header;
     memset(&header, 0, (size_t)SPTPersistentCacheRecordHeaderSize);
 
     ssize_t readSize = read(fd, &header, (size_t)SPTPersistentCacheRecordHeaderSize);
@@ -1477,7 +1477,7 @@ SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader,
 - (void)checkUpdateTimeForFileAtPath:(NSString *)path validate:(BOOL)validate referenceTimeCheck:(void(^)(uint64_t updateTime))timeCheck
 {
     XCTAssertNotNil(path, @"Path is nil");
-    SPTPersistentCacheRecordHeaderType header;
+    SPTPersistentCacheRecordHeader header;
     if (validate) {
         XCTAssertTrue(spt_test_ReadHeaderForFile(path.UTF8String, validate, &header), @"Unable to read and validate header");
         timeCheck(header.updateTimeSec);
@@ -1510,7 +1510,7 @@ SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader,
 
 @end
 
-static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersistentCacheRecordHeaderType *header)
+static BOOL spt_test_ReadHeaderForFile(const char* path, BOOL validate, SPTPersistentCacheRecordHeader *header)
 {
     int fd = open(path, O_RDONLY);
     if (fd == -1) {

--- a/Viewer/MainWindowController.m
+++ b/Viewer/MainWindowController.m
@@ -46,7 +46,7 @@
 
 @implementation MainWindowController
 {
-    SPTPersistentCacheRecordHeaderType _currHeader;
+    SPTPersistentCacheRecordHeader _currHeader;
     BOOL _crcValid;
 }
 
@@ -142,7 +142,7 @@
     NSString *fullFilePath = [self.cacheFiles objectAtIndex:idx];
     NSData *rawData = [NSData dataWithContentsOfFile:fullFilePath];
 
-    SPTPersistentCacheRecordHeaderType *h = SPTPersistentCacheGetHeaderFromData(__DECONST(void*, [rawData bytes]), [rawData length]);
+    SPTPersistentCacheRecordHeader *h = SPTPersistentCacheGetHeaderFromData(__DECONST(void*, [rawData bytes]), [rawData length]);
 
     if (h == NULL) {
         // TODO: error

--- a/include/SPTPersistentCache/SPTPersistentCache.h
+++ b/include/SPTPersistentCache/SPTPersistentCache.h
@@ -37,6 +37,8 @@ FOUNDATION_EXPORT double SPTDataLoaderVersionNumber;
 FOUNDATION_EXPORT const unsigned char SPTDataLoaderVersionString[];
 #endif // SPT_BUILDING_FRAMEWORK
 
+uint64_t spt_uint64rint(double value);
+
 /**
  * @brief SPTPersistentCache
  *

--- a/include/SPTPersistentCache/SPTPersistentCache.h
+++ b/include/SPTPersistentCache/SPTPersistentCache.h
@@ -37,8 +37,6 @@ FOUNDATION_EXPORT double SPTDataLoaderVersionNumber;
 FOUNDATION_EXPORT const unsigned char SPTDataLoaderVersionString[];
 #endif // SPT_BUILDING_FRAMEWORK
 
-uint64_t spt_uint64rint(double value);
-
 /**
  * @brief SPTPersistentCache
  *

--- a/include/SPTPersistentCache/SPTPersistentCacheHeader.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheHeader.h
@@ -55,6 +55,11 @@ typedef struct SPTPersistentCacheRecordHeaderType {
 FOUNDATION_EXPORT const SPTPersistentCacheMagicType SPTPersistentCacheMagicValue;
 FOUNDATION_EXPORT const size_t SPTPersistentCacheRecordHeaderSize;
 
+FOUNDATION_EXPORT SPTPersistentCacheRecordHeaderType SPTPersistentCacheRecordHeaderTypeMake(uint64_t ttl,
+                                                                                            uint64_t payloadSize,
+                                                                                            uint64_t updateTime,
+                                                                                            BOOL isLocked);
+
 // Following functions used internally and could be used for testing purposes also
 // Function return pointer to header if there are enough data otherwise NULL
 FOUNDATION_EXPORT SPTPersistentCacheRecordHeaderType *SPTPersistentCacheGetHeaderFromData(void *data,

--- a/include/SPTPersistentCache/SPTPersistentCacheHeader.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheHeader.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheRecordHeaderFlags) {
     SPTPersistentCacheRecordHeaderFlagsStreamIncomplete = 0x1,
 };
 
-typedef struct SPTPersistentCacheRecordHeaderType {
+typedef struct SPTPersistentCacheRecordHeader {
     // Version 1:
     SPTPersistentCacheMagicType magic;
     uint32_t headerSize;
@@ -50,26 +50,26 @@ typedef struct SPTPersistentCacheRecordHeaderType {
     uint32_t flags;         // See SPTPersistentRecordHeaderFlags
     uint32_t crc;
     // Version 2: Add fields here if required
-} SPTPersistentCacheRecordHeaderType;
+} SPTPersistentCacheRecordHeader;
 
 FOUNDATION_EXPORT const SPTPersistentCacheMagicType SPTPersistentCacheMagicValue;
 FOUNDATION_EXPORT const size_t SPTPersistentCacheRecordHeaderSize;
 
-FOUNDATION_EXPORT SPTPersistentCacheRecordHeaderType SPTPersistentCacheRecordHeaderTypeMake(uint64_t ttl,
-                                                                                            uint64_t payloadSize,
-                                                                                            uint64_t updateTime,
-                                                                                            BOOL isLocked);
+FOUNDATION_EXPORT SPTPersistentCacheRecordHeader SPTPersistentCacheRecordHeaderMake(uint64_t ttl,
+                                                                                    uint64_t payloadSize,
+                                                                                    uint64_t updateTime,
+                                                                                    BOOL isLocked);
 
 // Following functions used internally and could be used for testing purposes also
 // Function return pointer to header if there are enough data otherwise NULL
-FOUNDATION_EXPORT SPTPersistentCacheRecordHeaderType *SPTPersistentCacheGetHeaderFromData(void *data,
-                                                                                                  size_t size);
+FOUNDATION_EXPORT SPTPersistentCacheRecordHeader *SPTPersistentCacheGetHeaderFromData(void *data,
+                                                                                      size_t size);
 // Function validates header accoring to predefined rules used in production code
 // @return -1 if everything is ok, otherwise one of codes from SPTPersistentCacheLoadingError
-FOUNDATION_EXPORT int /*SPTPersistentCacheLoadingError*/ SPTPersistentCacheValidateHeader(const SPTPersistentCacheRecordHeaderType *header);
+FOUNDATION_EXPORT int /*SPTPersistentCacheLoadingError*/ SPTPersistentCacheValidateHeader(const SPTPersistentCacheRecordHeader *header);
 // Function return calculated CRC for current header.
-FOUNDATION_EXPORT uint32_t SPTPersistentCacheCalculateHeaderCRC(const SPTPersistentCacheRecordHeaderType *header);
+FOUNDATION_EXPORT uint32_t SPTPersistentCacheCalculateHeaderCRC(const SPTPersistentCacheRecordHeader *header);
 
 /// Checks that a given header is valid.
 /// @return nil if everything is ok, otherwise will return an instance of NSError.
-FOUNDATION_EXPORT NSError * SPTPersistentCacheCheckValidHeader(SPTPersistentCacheRecordHeaderType *header);
+FOUNDATION_EXPORT NSError * SPTPersistentCacheCheckValidHeader(SPTPersistentCacheRecordHeader *header);


### PR DESCRIPTION
- Create _Make_ function for `SPTPersistentCacheRecordHeaderType`
  
  and unit test it!
- Rename `SPTPersistentCacheRecordHeaderType` to `SPTPersistentCacheRecordHeader`.
  
  Following the convention of Apple's structures, dropped the **type** suffix of `SPTPersistentCacheRecordHeaderType`.
