### PR TITLE
Use Codecov for code coverage reporting

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,7 +1,0 @@
-coverage_service: coveralls
-ci_service: travis_ci
-xcodeproj: SPTPersistentCache.xcodeproj
-scheme: SPTPersistentCache
-ignore:
-  - "../**/Developer/*"
-  - "Tests/*"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods'
-gem 'slather'
 gem 'xcpretty'
 gem 'xcpretty-travis-formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     claide (0.9.1)
-    clamp (0.6.5)
     cocoapods (0.39.0)
       activesupport (>= 4.0.2)
       claide (~> 0.9.1)
@@ -42,18 +41,11 @@ GEM
     fuzzy_match (2.0.4)
     i18n (0.7.0)
     json (1.8.3)
-    mini_portile2 (2.0.0)
     minitest (5.8.4)
     molinillo (0.4.3)
     nap (1.1.0)
     netrc (0.7.8)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
     rouge (1.10.1)
-    slather (2.0.0)
-      clamp (~> 0.6)
-      nokogiri (~> 1.6.3)
-      xcodeproj (>= 0.28.2, < 1.1.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -71,7 +63,6 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods
-  slather
   xcpretty
   xcpretty-travis-formatter
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img alt="SPTPersistentCache" src="banner@2x.png" width="100%" max-width="888">
 
 [![Build Status](https://api.travis-ci.org/spotify/SPTPersistentCache.svg)](https://travis-ci.org/spotify/SPTPersistentCache)
-[![Coverage Status](https://coveralls.io/repos/spotify/SPTPersistentCache/badge.svg?branch=master&service=github)](https://coveralls.io/github/spotify/SPTPersistentCache?branch=master)
+[![Coverage Status](https://codecov.io/github/spotify/SPTPersistentCache/coverage.svg?branch=master)](https://codecov.io/github/spotify/SPTPersistentCache?branch=master)
 [![Documentation](https://img.shields.io/cocoapods/metrics/doc-percent/SPTPersistentCache.svg)](http://cocoadocs.org/docsets/SPTPersistentCache/)
 [![License](https://img.shields.io/github/license/spotify/SPTPersistentCache.svg)](LICENSE)
 [![CocoaPods](https://img.shields.io/cocoapods/v/SPTPersistentCache.svg)](https://cocoapods.org/?q=SPTPersistentCache)

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,8 +9,7 @@ We’re currently using the following stack:
 - OS X (as this is for Apple platforms).
 - Travis-CI for running the CI jobs.
   - Other CI provides might work.
-- Slather for handling code coverage reporting.
-  - We’re currently sending ours to Coveralls but you should be able to use any Slather supports.
+- Codecov for code coverage reporting and visualization.
 
 ## Installing
 There are primarily two routes on how to add the scripts to your repository. Either as a git submodule (only appropriate for apps) or using git subtree merging.
@@ -48,7 +47,7 @@ $ cp ci/sample/Gemfile .
 $ bundle update
 ```
 
-Next you should configure [Travis-CI](#travis---ci) and [Slather](slather)
+Next you should configure Travis-CI.
 
 ### Travis-CI
 Also have a look at the [travis.yml](sample/travis.yml) file.
@@ -66,9 +65,6 @@ The important environment variables you need to have set are:
 | `PODSPEC`                      	| The path to the project’s [CocoaPods](https://cocoapods.org/) podspec file.                	|
 | `EXPECTED_LICENSE_HEADER_FILE` 	| The path to a file containing the license header source files are expected to include.     	|
 | `LICENSED_SOURCE_FILES_GLOB`   	| A glob for finding all files which should be checked that they include the license header. 	|
-
-### Slather
-Also have a look at the [slather.yml](sample/slather.yml) file and have a look at [Slather’s own documentation](https://github.com/SlatherOrg/slather).
 
 ## Contributing :mailbox_with_mail:
 Contributions are welcomed, have a look at the [CONTRIBUTING.md](CONTRIBUTING.md) document for more information.

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -23,7 +23,6 @@ PATH="$SCRIPT_DIR/bin:$PATH"
 
 set -euo pipefail
 
-travis_fold_open "Slather" "Publishing test coverage data…"
-bundle exec slather coverage \
-    --input-format profdata
-travis_fold_close "Slather"
+travis_fold_open "Codecov" "Publishing test coverage data…"
+bash <(curl -s https://codecov.io/bash)
+travis_fold_close "Codecov"

--- a/ci/sample/Gemfile
+++ b/ci/sample/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods'
-gem 'slather'
 gem 'xcpretty'
 gem 'xcpretty-travis-formatter'


### PR DESCRIPTION
This since the service makes it easier to look at your coverage and find what to fix. It also removes the dependency on Slather. Reducing the amount of configs and set-up steps by one.
