### PR TITLE
Standardize style of SPTPersistentCache.h

### DIFF
--- a/include/SPTPersistentCache/SPTPersistentCache.h
+++ b/include/SPTPersistentCache/SPTPersistentCache.h
@@ -81,7 +81,6 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
 
 /**
  * @brief SPTPersistentCache
- *
  * @discussion Class defines persistent cache that manage files on disk. This class is threadsafe.
  * Except methods for scheduling/unscheduling GC which must be called on main thread.
  * It is obligatory that one instanse of that class manage one path branch on disk. In other case behavior is undefined.
@@ -90,16 +89,20 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
  * Cache GC procedure evicts all not locked files for which current_gc_time - creation_time > fileTTL.
  * Files that are locked not evicted by GC procedure and returned by the cache even if they already expired. 
  * Once unlocked, expired files would be collected by following GC
- * Req.#1.3 record opened as stream couldn't be altered by usual cache methods and doesn't take part in locked size calculation.
+ * Req.#1.3 record opened as stream couldn't be altered by usual cache methods and doesn't take part in locked size
+ * calculation.
  */
 @interface SPTPersistentCache : NSObject
 
+/**
+ * Designated initialiser.
+ * @param options The options to use for the cache parameters.
+ */
 - (instancetype)initWithOptions:(SPTPersistentCacheOptions *)options;
 
 /**
  * @discussion Load data from cache for specified key. 
  *             Req.#1.2. Expired records treated as not found on load. (And open stream)
- *
  * @param key Key used to access the data. It MUST MUST MUST be unique for different data. 
  *            It could be used as a part of file name. It up to a cache user to define algorithm to form a key.
  * @param callback callback to call once data is loaded. It mustn't be nil.
@@ -108,15 +111,12 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
 - (void)loadDataForKey:(NSString *)key
           withCallback:(SPTDataCacheResponseCallback)callback
                onQueue:(dispatch_queue_t)queue;
-
-
 /**
  * @discussion Load data for key which has specified prefix. chooseKeyCallback is called with array of matching keys.
  *             Req.#1.1a. To load the data user needs to pick one key and return it.
  *             Req.#1.1b. If non of those are match then return nil and cache will return not found error.
  *             chooseKeyCallback is called on any thread and caller should not do any heavy job in it.
  *             Req.#1.2. Expired records treated as not found on load. (And open stream)
- *
  * @param prefix Prefix which key should have to be candidate for loading.
  * @param chooseKeyCallback callback to call to define which key to use to load the data. 
  * @param callback callback to call once data is loaded. It mustn't be nil.
@@ -126,12 +126,10 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
                 chooseKeyCallback:(SPTDataCacheChooseKeyCallback)chooseKeyCallback
                      withCallback:(SPTDataCacheResponseCallback)callback
                           onQueue:(dispatch_queue_t)queue;
-
 /**
  * @discussion Req.#1.0. If data already exist for that key it will be overwritten otherwise created.
  * Its access time will be updated. RefCount depends on locked parameter.
  * Data is expired when current_gc_time - access_time > defaultExpirationPeriodSec.
- *
  * @param data Data to store. Mustn't be nil
  * @param key Key to associate the data with.
  * @param locked If YES then data refCount is set to 1. If NO then set to 0.
@@ -143,14 +141,11 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
            locked:(BOOL)locked
      withCallback:(SPTDataCacheResponseCallback)callback
           onQueue:(dispatch_queue_t)queue;
-
-
 /**
  * @discussion Req.#1.0. If data already exist for that key it will be overwritten otherwise created.
  * Its access time will be apdated. Its TTL will be updated if applicable.
  * RefCount depends on locked parameter.
  * Data is expired when current_gc_time - access_time > TTL.
- *
  * @param data Data to store. Mustn't be nil.
  * @param key Key to associate the data with.
  * @param ttl TTL value for a file. 0 is equivalent to storeData:forKey: behavior.
@@ -164,13 +159,12 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
            locked:(BOOL)locked
      withCallback:(SPTDataCacheResponseCallback)callback
           onQueue:(dispatch_queue_t)queue;
-
 /**
  * @discussion Update last access time in header of the record. Only applies for default expiration policy (ttl == 0).
  *             Locked files could be touched even if they are expired.
- *             Success callback is given if file was found and no errors occured even though nothing was changed due to ttl == 0.
+ *             Success callback is given if file was found and no errors occured even though nothing was changed due to
+ *             ttl == 0.
  *             Req.#1.2. Expired records treated as not found on touch.
- *
  * @param key Key which record header to update. Mustn't be nil.
  * @param callback May be nil if not interested in result.
  * @param queue Queue on which to run the callback. If callback is nil this is ignored otherwise mustn't be nil.
@@ -178,16 +172,14 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
 - (void)touchDataForKey:(NSString *)key
                callback:(SPTDataCacheResponseCallback)callback
                 onQueue:(dispatch_queue_t)queue;
-
 /**
  * @brief Removes data for keys unconditionally even if expired.
+ * @param keys The keys corresponding to the data to remove.
  */
 - (void)removeDataForKeys:(NSArray *)keys;
-
 /**
  * @discussion Increment ref count for given keys. Give callback with result for each key in input array.
  *             Req.#1.2. Expired records treated as not found on lock.
- *
  * @param keys Non nil non empty array of keys.
  * @param callback May be nil if not interested in result.
  * @param queue Queue on which to run the callback. If callback is nil this is ignored otherwise mustn't be nil.
@@ -195,11 +187,9 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
 - (void)lockDataForKeys:(NSArray *)keys
                callback:(SPTDataCacheResponseCallback)callback
                 onQueue:(dispatch_queue_t)queue;
-
 /**
  * @discussion Decrement ref count for given keys. Give callback with result for each key in input array.
  *             If decrements exceeds increments assertion is given.
- *
  * @param keys Non nil non empty array of keys.
  * @param callback May be nil if not interested in result.
  * @param queue Queue on which to run the callback. If callback is nil this is ignored otherwise mustn't be nil.
@@ -207,45 +197,36 @@ FOUNDATION_EXPORT NSString *const SPTPersistentCacheErrorDomain;
 - (void)unlockDataForKeys:(NSArray *)keys
                  callback:(SPTDataCacheResponseCallback)callback
                   onQueue:(dispatch_queue_t)queue;
-
 /**
- * Schedule ragbage collection. If already scheduled then this method does nothing.
- * WARNING: This method has to be called on main thread.
+ * Schedule garbage collection. If already scheduled then this method does nothing.
+ * @warning This method has to be called on main thread.
  */
 - (void)scheduleGarbageCollector;
-
 /**
  * Stop ragbage collection. If already stopped this method does nothing.
- * WARNING: This method has to be called on main thread.
+ * @warning This method has to be called on main thread.
  */
 - (void)unscheduleGarbageCollector;
-
 /**
  * Delete all files files in managed folder unconditionaly.
  */
 - (void)prune;
-
 /**
  * Wipe only files that locked regardless of refCount value.
  */
 - (void)wipeLockedFiles;
-
 /**
  * Wipe only files that are not locked regardles of their expiration time.
  */
 - (void)wipeNonLockedFiles;
-
 /**
  * Returns size occupied by cache.
- * WARNING: This method does synchronous calculations.
- * WARNING: Files opened as streams are accounted in this calculations.
+ * @warning This method does synchronous calculations.
  */
 - (NSUInteger)totalUsedSizeInBytes;
-
 /**
  * Returns size occupied by locked items.
- * WARNING: This method does synchronous calculations.
- * WARNING: Files opened as streams are NOT accounted in this calculations.
+ * @warning This method does synchronous calculations.
  */
 - (NSUInteger)lockedItemsSizeInBytes;
 


### PR DESCRIPTION
- Remove spaces where they are not needed
- Add documentation on some undocumented methods
- Add param and warning tags to the docs
