### PR TITLE
Add -description and -debugDescription to model classes

### DIFF
--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		698B70721C7538B000BDBFEA /* f50512901688b79a7852999d384d097a71fad788 in Resources */ = {isa = PBXBuildFile; fileRef = 698B70611C7538B000BDBFEA /* f50512901688b79a7852999d384d097a71fad788 */; };
 		698B70731C7538B000BDBFEA /* f7501f27f70162a9a7da196c5d2ece3151a2d80a in Resources */ = {isa = PBXBuildFile; fileRef = 698B70621C7538B000BDBFEA /* f7501f27f70162a9a7da196c5d2ece3151a2d80a */; };
 		698B70741C7538B000BDBFEA /* fc22d4f65c1ba875f6bb5ba7d35a7fd12851ed5c in Resources */ = {isa = PBXBuildFile; fileRef = 698B70631C7538B000BDBFEA /* fc22d4f65c1ba875f6bb5ba7d35a7fd12851ed5c */; };
+		9C9E70711C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70701C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m */; };
+		9C9E70731C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70721C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m */; };
+		9C9E70761C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70751C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m */; };
 		C41237081C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m */; };
 		C413BA011C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */; };
 		C413BA051C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA041C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m */; };
@@ -111,6 +114,11 @@
 		698B70631C7538B000BDBFEA /* fc22d4f65c1ba875f6bb5ba7d35a7fd12851ed5c */ = {isa = PBXFileReference; lastKnownFileType = file; path = fc22d4f65c1ba875f6bb5ba7d35a7fd12851ed5c; sourceTree = "<group>"; };
 		9C882A801C65422700D463BB /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
 		9C882A811C65422700D463BB /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
+		9C9E706F1C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheObjectDescription.h; sourceTree = "<group>"; };
+		9C9E70701C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheObjectDescription.m; sourceTree = "<group>"; };
+		9C9E70721C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheObjectDescriptionTests.m; sourceTree = "<group>"; };
+		9C9E70741C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheObjectDescriptionStyleValidator.h; sourceTree = "<group>"; };
+		9C9E70751C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheObjectDescriptionStyleValidator.m; sourceTree = "<group>"; };
 		C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheTimerProxyTests.m; sourceTree = "<group>"; };
 		C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheHeaderTests.m; sourceTree = "<group>"; };
 		C413BA031C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SPTPersistentCacheDomainErrors.h"; path = "Categories/NSError+SPTPersistentCacheDomainErrors.h"; sourceTree = "<group>"; };
@@ -169,15 +177,18 @@
 		0510FF221BA2FF7A00ED0766 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				698B70521C7538B000BDBFEA /* Resources */,
-				0510FF6A1BA3073D00ED0766 /* SPTPersistentCacheTests.m */,
-				C4B4148B1C6A01970099FECD /* SPTPersistentCacheRecordTests.m */,
-				C4B4148E1C6A1BED0099FECD /* SPTPersistentCacheResponseTests.m */,
-				C4B414901C6A24A10099FECD /* SPTPersistentCacheOptionsTests.m */,
-				C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m */,
-				C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */,
 				C413BA061C71E2DC002D41FB /* NSError+SPTPersistentCacheDomainErrorsTests.m */,
 				C48AE7401C75BB8300814D7D /* SPTPersistentCacheFileManagerTests.m */,
+				C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */,
+				9C9E70741C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.h */,
+				9C9E70751C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m */,
+				9C9E70721C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m */,
+				C4B414901C6A24A10099FECD /* SPTPersistentCacheOptionsTests.m */,
+				C4B4148B1C6A01970099FECD /* SPTPersistentCacheRecordTests.m */,
+				C4B4148E1C6A1BED0099FECD /* SPTPersistentCacheResponseTests.m */,
+				0510FF6A1BA3073D00ED0766 /* SPTPersistentCacheTests.m */,
+				C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m */,
+				698B70521C7538B000BDBFEA /* Resources */,
 				0510FF231BA2FF7A00ED0766 /* Supporting Files */,
 			);
 			path = Tests;
@@ -217,18 +228,20 @@
 				C413BA021C71E0CF002D41FB /* Categories */,
 				696CD7841C4707E20071DD18 /* crc32iso3309.c */,
 				696CD7851C4707E20071DD18 /* crc32iso3309.h */,
-				0595F33B1C5011E30052328B /* SPTPersistentCache+Private.h */,
 				696CD7861C4707E20071DD18 /* SPTPersistentCache.m */,
-				696CD7871C4707E20071DD18 /* SPTPersistentCacheOptions.m */,
-				0595F0AB1C5008AB0052328B /* SPTPersistentCacheRecord+Private.h */,
-				0595F0A81C5008060052328B /* SPTPersistentCacheRecord.m */,
-				0595F0B21C500A540052328B /* SPTPersistentCacheResponse+Private.h */,
-				0595F0AF1C5009800052328B /* SPTPersistentCacheResponse.m */,
-				0595F3381C50117B0052328B /* SPTPersistentCacheTimerProxy.h */,
-				0595F3391C50117B0052328B /* SPTPersistentCacheTimerProxy.m */,
-				057AFD5A1C70F99A00350C9F /* SPTPersistentCacheHeader.m */,
+				0595F33B1C5011E30052328B /* SPTPersistentCache+Private.h */,
 				C48AE4621C74A7F800814D7D /* SPTPersistentCacheFileManager.h */,
 				C48AE4631C74A7F800814D7D /* SPTPersistentCacheFileManager.m */,
+				057AFD5A1C70F99A00350C9F /* SPTPersistentCacheHeader.m */,
+				9C9E706F1C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.h */,
+				9C9E70701C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m */,
+				696CD7871C4707E20071DD18 /* SPTPersistentCacheOptions.m */,
+				0595F0A81C5008060052328B /* SPTPersistentCacheRecord.m */,
+				0595F0AB1C5008AB0052328B /* SPTPersistentCacheRecord+Private.h */,
+				0595F0AF1C5009800052328B /* SPTPersistentCacheResponse.m */,
+				0595F0B21C500A540052328B /* SPTPersistentCacheResponse+Private.h */,
+				0595F3381C50117B0052328B /* SPTPersistentCacheTimerProxy.h */,
+				0595F3391C50117B0052328B /* SPTPersistentCacheTimerProxy.m */,
 				C45526AD1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.h */,
 				C45526AE1C77D7ED008D5570 /* SPTPersistentCacheTypeUtilities.m */,
 			);
@@ -390,6 +403,7 @@
 			files = (
 				C413BA051C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m in Sources */,
 				C48AE4641C74A7F800814D7D /* SPTPersistentCacheFileManager.m in Sources */,
+				9C9E70711C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */,
 				0595F33A1C50117B0052328B /* SPTPersistentCacheTimerProxy.m in Sources */,
 				0595F0A91C5008060052328B /* SPTPersistentCacheRecord.m in Sources */,
 				057AFD5B1C70F99A00350C9F /* SPTPersistentCacheHeader.m in Sources */,
@@ -408,10 +422,12 @@
 				C4B414911C6A24A10099FECD /* SPTPersistentCacheOptionsTests.m in Sources */,
 				0510FF6B1BA3073D00ED0766 /* SPTPersistentCacheTests.m in Sources */,
 				C413BA011C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m in Sources */,
+				9C9E70761C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m in Sources */,
 				C41237081C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m in Sources */,
 				C413BA071C71E2DC002D41FB /* NSError+SPTPersistentCacheDomainErrorsTests.m in Sources */,
 				C4B4148F1C6A1BED0099FECD /* SPTPersistentCacheResponseTests.m in Sources */,
 				C48AE7411C75BB8300814D7D /* SPTPersistentCacheFileManagerTests.m in Sources */,
+				9C9E70731C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		9C9E70711C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70701C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m */; };
 		9C9E70731C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70721C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m */; };
 		9C9E70761C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70751C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m */; };
+		9C9E70781C790ED900E1CBE6 /* SPTPersistentCacheRecordTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C4B4148B1C6A01970099FECD /* SPTPersistentCacheRecordTests.m */; };
 		C41237081C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheTimerProxyTests.m */; };
 		C413BA011C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */; };
 		C413BA051C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = C413BA041C71E1A0002D41FB /* NSError+SPTPersistentCacheDomainErrors.m */; };
@@ -419,6 +420,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C9E70781C790ED900E1CBE6 /* SPTPersistentCacheRecordTests.m in Sources */,
 				C4B414911C6A24A10099FECD /* SPTPersistentCacheOptionsTests.m in Sources */,
 				0510FF6B1BA3073D00ED0766 /* SPTPersistentCacheTests.m in Sources */,
 				C413BA011C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m in Sources */,

--- a/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
+++ b/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0510FF121BA2FF7A00ED0766"

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -421,6 +421,8 @@
 				PRODUCT_NAME = SPTPersistentCache;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -438,6 +440,8 @@
 				PRODUCT_NAME = SPTPersistentCache;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-iOS";
 				PRODUCT_NAME = SPTPersistentCache;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				VALID_ARCHS = "i386 x86_64 armv7 arm64 armv7s";
 			};
 			name = Debug;
 		};
@@ -400,6 +402,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-iOS";
 				PRODUCT_NAME = SPTPersistentCache;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				VALID_ARCHS = "i386 x86_64 armv7 arm64 armv7s";
 			};
 			name = Release;
 		};

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9C9E707B1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70791C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m */; };
+		9C9E707C1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C9E707A1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h */; };
+		9C9E707D1C790F3700E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70791C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m */; };
+		9C9E707E1C790F3B00E1CBE6 /* SPTPersistentCacheObjectDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C9E707A1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h */; };
 		C45526B41C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */; };
 		C45526B51C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */; };
 		C45526B61C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C45526B31C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m */; };
@@ -59,6 +63,8 @@
 		052021FB1C7382C6003A4FB4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		052022061C738600003A4FB4 /* project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = project.xcconfig; path = ../project.xcconfig; sourceTree = "<group>"; };
 		052022091C738637003A4FB4 /* spotify_os.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = spotify_os.xcconfig; path = ../spotify_os.xcconfig; sourceTree = "<group>"; };
+		9C9E70791C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheObjectDescription.m; sourceTree = "<group>"; };
+		9C9E707A1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheObjectDescription.h; sourceTree = "<group>"; };
 		C45526B21C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheTypeUtilities.h; sourceTree = "<group>"; };
 		C45526B31C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheTypeUtilities.m; sourceTree = "<group>"; };
 		DD1D23791C77857900D0477A /* SPTPersistentCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCache.h; sourceTree = "<group>"; };
@@ -145,6 +151,8 @@
 				DD1D23941C7785A900D0477A /* SPTPersistentCacheFileManager.h */,
 				DD1D23951C7785A900D0477A /* SPTPersistentCacheFileManager.m */,
 				DD1D23961C7785A900D0477A /* SPTPersistentCacheHeader.m */,
+				9C9E707A1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h */,
+				9C9E70791C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m */,
 				DD1D23971C7785A900D0477A /* SPTPersistentCacheOptions.m */,
 				DD1D23981C7785A900D0477A /* SPTPersistentCacheRecord.m */,
 				DD1D23991C7785A900D0477A /* SPTPersistentCacheRecord+Private.h */,
@@ -197,6 +205,7 @@
 				DD1D23A31C7785A900D0477A /* crc32iso3309.h in Headers */,
 				DD1D23AE1C7785A900D0477A /* SPTPersistentCacheTimerProxy.h in Headers */,
 				DD1D23A51C7785A900D0477A /* SPTPersistentCache+Private.h in Headers */,
+				9C9E707C1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h in Headers */,
 				DD1D23811C77857900D0477A /* SPTPersistentCacheOptions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -213,6 +222,7 @@
 				DD1D23B31C7785AE00D0477A /* crc32iso3309.h in Headers */,
 				DD1D23BD1C7785AE00D0477A /* SPTPersistentCacheResponse+Private.h in Headers */,
 				DD1D23871C77857E00D0477A /* SPTPersistentCacheOptions.h in Headers */,
+				9C9E707E1C790F3B00E1CBE6 /* SPTPersistentCacheObjectDescription.h in Headers */,
 				DD1D23891C77857E00D0477A /* SPTPersistentCacheResponse.h in Headers */,
 				C45526B51C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.h in Headers */,
 				DD1D23861C77857E00D0477A /* SPTPersistentCacheHeader.h in Headers */,
@@ -319,6 +329,7 @@
 			files = (
 				DD1D23AA1C7785A900D0477A /* SPTPersistentCacheRecord.m in Sources */,
 				DD1D23A21C7785A900D0477A /* crc32iso3309.c in Sources */,
+				9C9E707B1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */,
 				DD1D23AF1C7785A900D0477A /* SPTPersistentCacheTimerProxy.m in Sources */,
 				DD1D23A71C7785A900D0477A /* SPTPersistentCacheFileManager.m in Sources */,
 				DD1D239F1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.m in Sources */,
@@ -343,6 +354,7 @@
 				DD1D23B91C7785AE00D0477A /* SPTPersistentCacheOptions.m in Sources */,
 				DD1D23B41C7785AE00D0477A /* SPTPersistentCache.m in Sources */,
 				C45526B71C77DCCC008D5570 /* SPTPersistentCacheTypeUtilities.m in Sources */,
+				9C9E707D1C790F3700E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/SPTPersistentCacheObjectDescription.h
+++ b/Sources/SPTPersistentCacheObjectDescription.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#import <Foundation/Foundation.h>
+
+/// The termination sentinel that must be used toghether with `SPTPersistentCacheObjectDescription()`.
+extern id const SPTPersistentCacheObjectDescriptionTerminationSentinel;
+
+/**
+ * Creates a standardized description string for the given _object_ and a variable list of _value_ to _key_ pairs.
+ * Each value and key must be an object conforming to the `NSObject` protocol.
+ *
+ * The function takes a variable list of value and key pairs. Just like the variadic `NSDictionary` initializer. You
+ * must terminate the list using `SPTPersistentCacheObjectDescriptionTerminationSentinel`.
+ *
+ * @note It’s recommended that you use the convenience macro `SPTPersistentCacheObjectDescription` over this function
+ * directly. As it adds the termination sentinel for you.
+ *
+ * @warning The list of variadic arguments **MUST** end with the custom termination sentinel:
+ * `SPTPersistentCacheObjectDescriptionTerminationSentinel`. We need a custom sentinel as the function supports
+ * arguments being `nil`.
+ *
+ * @return A standardized description string on the format `<ClassName: 0x1234abcd; key1 = "value1"; key2 = "value2">`.
+ */
+extern NSString *_SPTPersistentCacheObjectDescription(id<NSObject> object, id<NSObject> firstValue, ...);
+
+/**
+ * Creates a standardized description string for the given _object_ and a variable list of _value_ to _key_ pairs.
+ *
+ * The function takes a variable list of value and key pairs. Just like the variadic `NSDictionary` initializer. It
+ * will automatically insert the termination sentinel for you.
+ *
+ * @return A standardized description string on the format `<ClassName: 0x1234abcd; key1 = "value1"; key2 = "value2">`.
+ */
+#define SPTPersistentCacheObjectDescription(object, firstValue, ...) _SPTPersistentCacheObjectDescription((object), (firstValue), __VA_ARGS__, SPTPersistentCacheObjectDescriptionTerminationSentinel)

--- a/Sources/SPTPersistentCacheObjectDescription.m
+++ b/Sources/SPTPersistentCacheObjectDescription.m
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#import "SPTPersistentCacheObjectDescription.h"
+
+id const SPTPersistentCacheObjectDescriptionTerminationSentinel = @"0xDEADC0DE";
+
+NS_INLINE BOOL SPTIsObjectDescriptionTerminationSentinel(id const object)
+{
+    return object == SPTPersistentCacheObjectDescriptionTerminationSentinel;
+}
+
+static void SPTPersistentCacheObjectDescriptionAppendToString(NSMutableString *description, id<NSObject> object, id<NSObject> firstValue, va_list valueKeyPairs)
+{
+    NSCParameterAssert(description);
+    NSCParameterAssert(object);
+
+    id<NSObject> value = firstValue;
+    id<NSObject> key = va_arg(valueKeyPairs, id);
+
+    while (!SPTIsObjectDescriptionTerminationSentinel(value) && !SPTIsObjectDescriptionTerminationSentinel(key)) {
+        if (value != object && key != object) {
+            [description appendFormat:@"; %@ = \"%@\"", key, value];
+        }
+
+        value = va_arg(valueKeyPairs, id);
+        if (SPTIsObjectDescriptionTerminationSentinel(value)) {
+            break;
+        }
+
+        key = va_arg(valueKeyPairs, id);
+    }
+
+}
+
+NSString *_SPTPersistentCacheObjectDescription(id<NSObject> object, id<NSObject> firstValue, ...)
+{
+    if (object == nil) {
+        return nil;
+    }
+
+    NSString * const objectClassName = NSStringFromClass(object.class);
+    NSMutableString * const description = [NSMutableString stringWithFormat:@"<%@: %p", objectClassName, (void *)object];
+
+    NSString * (^ const closeAndReturnDescriptionBlock)(void) = ^{
+        [description appendString:@">"];
+        return [description copy];
+    };
+
+    if (SPTIsObjectDescriptionTerminationSentinel(firstValue)) {
+        return closeAndReturnDescriptionBlock();
+    }
+
+    va_list valueKeyPairs;
+    va_start(valueKeyPairs, firstValue);
+    SPTPersistentCacheObjectDescriptionAppendToString(description, object, firstValue, valueKeyPairs);
+    va_end(valueKeyPairs);
+
+    return closeAndReturnDescriptionBlock();
+}

--- a/Sources/SPTPersistentCacheOptions.m
+++ b/Sources/SPTPersistentCacheOptions.m
@@ -19,6 +19,7 @@
  * under the License.
  */
 #import "SPTPersistentCacheOptions.h"
+#import "SPTPersistentCacheObjectDescription.h"
 
 void SPTPersistentCacheOptionsDebug(NSString *debugMessage, SPTPersistentCacheDebugCallback debugCallback);
 
@@ -116,6 +117,25 @@ const NSUInteger SPTPersistentCacheMinimumExpirationLimit = 60;
                            (unsigned long)_gcIntervalSec, (unsigned long)_defaultExpirationPeriodSec, (void *)self];
     
     return self;
+}
+
+#pragma mark Describing Object
+
+- (NSString *)description
+{
+    return SPTPersistentCacheObjectDescription(self, self.cacheIdentifier, @"cache-identifier");
+}
+
+- (NSString *)debugDescription
+{
+    return SPTPersistentCacheObjectDescription(self,
+                                               self.cacheIdentifier, @"cache-identifier",
+                                               self.cachePath, @"cache-path",
+                                               self.identifierForQueue, @"identifier-for-queue",
+                                               @(self.folderSeparationEnabled), @"folder-separation",
+                                               @(self.gcIntervalSec), @"gc-interval-seconds",
+                                               @(self.defaultExpirationPeriodSec), @"default-expiration-period-seconds",
+                                               @(self.sizeConstraintBytes), @"size-constraint-bytes");
 }
 
 @end

--- a/Sources/SPTPersistentCacheRecord.m
+++ b/Sources/SPTPersistentCacheRecord.m
@@ -46,7 +46,7 @@
 
 - (NSString *)description
 {
-    return SPTPersistentCacheObjectDescription(self, self.key, @"key", @"lol", @"wut");
+    return SPTPersistentCacheObjectDescription(self, self.key, @"key");
 }
 
 - (NSString *)debugDescription

--- a/Sources/SPTPersistentCacheRecord.m
+++ b/Sources/SPTPersistentCacheRecord.m
@@ -19,6 +19,7 @@
  * under the License.
  */
 #import "SPTPersistentCacheRecord.h"
+#import "SPTPersistentCacheObjectDescription.h"
 
 @implementation SPTPersistentCacheRecord
 
@@ -39,6 +40,18 @@
     _data = data;
 
     return self;
+}
+
+#pragma mark Describing Object
+
+- (NSString *)description
+{
+    return SPTPersistentCacheObjectDescription(self, self.key, @"key", @"lol", @"wut");
+}
+
+- (NSString *)debugDescription
+{
+    return SPTPersistentCacheObjectDescription(self, self.key, @"key", @(self.ttl), @"ttl", @(self.refCount), @"ref-count");
 }
 
 @end

--- a/Sources/SPTPersistentCacheResponse.m
+++ b/Sources/SPTPersistentCacheResponse.m
@@ -19,6 +19,8 @@
  * under the License.
  */
 #import <SPTPersistentCache/SPTPersistentCacheResponse.h>
+#import <SPTPersistentCache/SPTPersistentCacheRecord.h>
+#import "SPTPersistentCacheObjectDescription.h"
 
 @interface SPTPersistentCacheResponse ()
 
@@ -43,6 +45,30 @@
     _record = record;
 
     return self;
+}
+
+#pragma mark Describing Object
+
+NS_INLINE NSString *NSStringFromSPTPersistentCacheResponseCode(SPTPersistentCacheResponseCode code)
+{
+    switch (code) {
+        case SPTPersistentCacheResponseCodeNotFound:            return @"not-found";
+        case SPTPersistentCacheResponseCodeOperationError:      return @"operation-error";
+        case SPTPersistentCacheResponseCodeOperationSucceeded:  return @"operation-success";
+    }
+}
+
+- (NSString *)description
+{
+    return SPTPersistentCacheObjectDescription(self, NSStringFromSPTPersistentCacheResponseCode(self.result), @"result");
+}
+
+- (NSString *)debugDescription
+{
+    return SPTPersistentCacheObjectDescription(self,
+                                               NSStringFromSPTPersistentCacheResponseCode(self.result), @"result",
+                                               self.record.debugDescription, @"record",
+                                               self.error.debugDescription, @"error");
 }
 
 @end

--- a/Tests/SPTPersistentCacheObjectDescriptionStyleValidator.h
+++ b/Tests/SPTPersistentCacheObjectDescriptionStyleValidator.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#import <Foundation/Foundation.h>
+
+/**
+ * Class which validates object descriptions for conformance to the expected style.
+ *
+ * A valid description adheres to the following pattern:
+ * - <ClassName: 0x0123456789abcdefABCDEF>`
+ * - <ClassName: 0x0123456789abcdefABCDEF; key = "foo">
+ * - <ClassName: 0x0123456789abcdefABCDEF; key = "foo"; bar-bar = "hello">
+ */
+@interface SPTPersistentCacheObjectDescriptionStyleValidator : NSObject
+
+/**
+ * Valides the given _description_ for style conformance.
+ *
+ * @param description A string description of an object which should be validated.
+ *
+ * @return A boolean indicating if the _description_ is valid stylewise.
+ */
+- (BOOL)isValidStyleDescription:(NSString *)description;
+
+@end

--- a/Tests/SPTPersistentCacheObjectDescriptionStyleValidator.m
+++ b/Tests/SPTPersistentCacheObjectDescriptionStyleValidator.m
@@ -45,6 +45,11 @@
 
 - (BOOL)isValidStyleDescription:(NSString *)description
 {
+    // Shorter than: <A: 0x0>
+    if (description.length < 8) {
+        return NO;
+    }
+
     const NSRange descriptionRange = NSMakeRange(0, description.length);
     const NSMatchingOptions options = (NSMatchingOptions)0;
     const NSUInteger matches = [self.regex numberOfMatchesInString:description options:options range:descriptionRange];

--- a/Tests/SPTPersistentCacheObjectDescriptionStyleValidator.m
+++ b/Tests/SPTPersistentCacheObjectDescriptionStyleValidator.m
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#import "SPTPersistentCacheObjectDescriptionStyleValidator.h"
+
+@interface SPTPersistentCacheObjectDescriptionStyleValidator ()
+
+@property (nonatomic, strong) NSRegularExpression *regex;
+
+@end
+
+@implementation SPTPersistentCacheObjectDescriptionStyleValidator
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        // Regex to match a description: ^<[\w]+: 0x[\da-fA-F]+((; [^=]+= "[^"]+")+)?>$
+
+        // The NSRegularExpression class is currently only available in the Foundation framework of iOS 4
+        _regex = [NSRegularExpression regularExpressionWithPattern:@"^<[\\w]+: 0x[\\da-fA-F]+((; [^=]+= \"[^\"]+\")+)?>$"
+                                                           options:NSRegularExpressionAnchorsMatchLines
+                                                             error:nil];
+    }
+
+    return self;
+}
+
+- (BOOL)isValidStyleDescription:(NSString *)description
+{
+    const NSRange descriptionRange = NSMakeRange(0, description.length);
+    const NSMatchingOptions options = (NSMatchingOptions)0;
+    const NSUInteger matches = [self.regex numberOfMatchesInString:description options:options range:descriptionRange];
+
+    return matches == 1;
+}
+
+@end

--- a/Tests/SPTPersistentCacheObjectDescriptionTests.m
+++ b/Tests/SPTPersistentCacheObjectDescriptionTests.m
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#import <XCTest/XCTest.h>
+
+#import "SPTPersistentCacheObjectDescription.h"
+#import "SPTPersistentCacheObjectDescriptionStyleValidator.h"
+
+@interface SPTPersistentCacheObjectDescriptionTests : XCTestCase
+
+@property (nonatomic, strong) SPTPersistentCacheObjectDescriptionStyleValidator *styleValidator;
+
+@end
+
+@implementation SPTPersistentCacheObjectDescriptionTests
+
+#pragma mark Test Life Time
+
+- (void)setUp
+{
+    [super setUp];
+    self.styleValidator = [SPTPersistentCacheObjectDescriptionStyleValidator new];
+}
+
+#pragma mark Basic Properties
+
+- (void)testNilObject
+{
+    XCTAssertNil(_SPTPersistentCacheObjectDescription(nil, @"value1", @"ke1", SPTPersistentCacheObjectDescriptionTerminationSentinel));
+}
+
+- (void)testWithoutValues
+{
+    NSString * const object = @"object1";
+    NSString * const expected = [NSString stringWithFormat:@"<%@: %p>", object.class, (void *)object];
+
+    NSString * const description = _SPTPersistentCacheObjectDescription(object, SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertEqualObjects(description, expected);
+}
+
+- (void)testSingleValueKeyPair
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \"value1\""];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the key-value pair. Description: \"%@\"", description1);
+}
+
+- (void)testMultipleValueKey
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", @"value2", @"key2", SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \"value1\""];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the first key-value pair. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair2Range = [description1 rangeOfString:@"key2 = \"value2\""];
+    XCTAssertNotEqual(keyValuePair2Range.location, NSNotFound, @"The description should contain the second key-value pair. Description: \"%@\"", description1);
+
+    XCTAssertGreaterThan(keyValuePair2Range.location, keyValuePair1Range.location, @"The second key-value pair should come after the first. Description: \"%@\"", description1);
+}
+
+- (void)testNilValue
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+    NSString * const expectedKeyValueString = [NSString stringWithFormat:@"key1 = \"%@\"", nil];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, nil, @"key1", SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:expectedKeyValueString];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the key-value pair. Description: \"%@\"", description1);
+}
+
+- (void)testNilKey
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+    NSString * const expectedKeyValueString = [NSString stringWithFormat:@"%@ = \"value1\"", nil];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", nil, SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:expectedKeyValueString];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the key-value pair. Description: \"%@\"", description1);
+}
+
+- (void)testMultipleTerminationSentinels
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", SPTPersistentCacheObjectDescriptionTerminationSentinel, @"value2", @"key2", SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \"value1\""];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the first key-value pair. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair2Range = [description1 rangeOfString:@"key2 = \"value2\""];
+    XCTAssertEqual(keyValuePair2Range.location, NSNotFound, @"The description should NOT contain the second key-value pair as it comes after a termination sentinel. Description: \"%@\"", description1);
+}
+
+- (void)testMisalignedFirstValueKeyPairs
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", SPTPersistentCacheObjectDescriptionTerminationSentinel, @"key1", @"value2", @"key2");
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \"value1\""];
+    XCTAssertEqual(keyValuePair1Range.location, NSNotFound, @"The description should NOT contain the first key-value pair since it’s misaligned. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair2Range = [description1 rangeOfString:@"key2 = \"value2\""];
+    XCTAssertEqual(keyValuePair2Range.location, NSNotFound, @"The description should NOT contain the second key-value pair as it comes after a termination sentinel. Description: \"%@\"", description1);
+}
+
+- (void)testMisalignedSecondValueKeyPairs
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", @"value2", SPTPersistentCacheObjectDescriptionTerminationSentinel, @"key2");
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \"value1\""];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the first key-value pair. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair2Range = [description1 rangeOfString:@"key2 = \"value2\""];
+    XCTAssertEqual(keyValuePair2Range.location, NSNotFound, @"The description should NOT contain the second key-value pair as it’s misaligned. Description: \"%@\"", description1);
+}
+
+- (void)testMissingKey
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const expectedPrefix = [NSString stringWithFormat:@"<%@: 0x", object1.class];
+
+    NSString * const description1 = SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", @"value2", @"key2", @"value3");
+
+    XCTAssertTrue([self.styleValidator isValidStyleDescription:description1], @"A description must be of the valid style `<ClassName: pointer-address; key1 = \"value1\"; key2 = \"value2\"; ...>`. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasPrefix:expectedPrefix], @"The description should have the expected prefix containing the class name. Description: \"%@\"", description1);
+    XCTAssertTrue([description1 hasSuffix:@">"], @"The description should always end with `>`. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \"value1\""];
+    XCTAssertNotEqual(keyValuePair1Range.location, NSNotFound, @"The description should contain the first key-value pair. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair2Range = [description1 rangeOfString:@"key2 = \"value2\""];
+    XCTAssertNotEqual(keyValuePair2Range.location, NSNotFound, @"The description should contain the second key-value pair. Description: \"%@\"", description1);
+
+    const NSRange value3Range = [description1 rangeOfString:@"value3"];
+    XCTAssertEqual(value3Range.location, NSNotFound, @"The description should NOT contain the third value as the key is missing. Description: \"%@\"", description1);
+}
+
+- (void)testIsStable
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const description1 = _SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", @32, @42, SPTPersistentCacheObjectDescriptionTerminationSentinel);
+    NSString * const description2 = _SPTPersistentCacheObjectDescription(object1, @"value1", @"key1", @32, @42, SPTPersistentCacheObjectDescriptionTerminationSentinel);
+
+    XCTAssertEqualObjects(description1, description2);
+}
+
+- (void)testDetecsRecursiveDescription
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const description1 = SPTPersistentCacheObjectDescription(object1, object1, @"key1", @32, @42);
+
+    const NSRange keyValuePair1Range = [description1 rangeOfString:@"key1 = \""];
+    XCTAssertEqual(keyValuePair1Range.location, NSNotFound, @"The description should NOT contain the first key-value pair as it would be recursive. Description: \"%@\"", description1);
+
+    const NSRange keyValuePair2Range = [description1 rangeOfString:@"42 = \"32\""];
+    XCTAssertNotEqual(keyValuePair2Range.location, NSNotFound, @"The description should contain the second key-value pair. Description: \"%@\"", description1);
+}
+
+#pragma mark Convenience Macro
+
+- (void)testConvenienceMacroProcudeSameResultAsDirectFunctionAccess
+{
+    NSString * const object1 = @"object1";
+
+    NSString * const directDescription = _SPTPersistentCacheObjectDescription(object1, @"foo", @"bar", @"hi", @"hello", SPTPersistentCacheObjectDescriptionTerminationSentinel);
+    NSString * const macroDescription = SPTPersistentCacheObjectDescription(object1, @"foo", @"bar", @"hi", @"hello");
+
+    XCTAssertEqualObjects(directDescription, macroDescription);
+}
+
+@end

--- a/Tests/SPTPersistentCacheOptionsTests.m
+++ b/Tests/SPTPersistentCacheOptionsTests.m
@@ -28,10 +28,15 @@
 
 @implementation SPTPersistentCacheOptionsTests
 
+- (void)setUp
+{
+    [super setUp];
+
+    self.dataCacheOptions = [SPTPersistentCacheOptions new];
+}
+
 - (void)testDefaultInitializer
 {
-    self.dataCacheOptions = [[SPTPersistentCacheOptions alloc] init];
-    
     XCTAssertEqual(self.dataCacheOptions.folderSeparationEnabled, YES);
     XCTAssertEqual(self.dataCacheOptions.gcIntervalSec, SPTPersistentCacheDefaultGCIntervalSec);
     XCTAssertEqual(self.dataCacheOptions.defaultExpirationPeriodSec,
@@ -43,27 +48,25 @@
 
 - (void)testMinimumGarbageColectorInterval
 {
-    self.dataCacheOptions = [[SPTPersistentCacheOptions alloc] initWithCachePath:nil
-                                                                          identifier:nil
-
-                                                                 currentTimeCallback:nil
-                                                           defaultExpirationInterval:1
-                                                            garbageCollectorInterval:1
-                                                                               debug:nil];
-    XCTAssertEqual(self.dataCacheOptions.gcIntervalSec,
+    SPTPersistentCacheOptions *dataCacheOptions = [[SPTPersistentCacheOptions alloc] initWithCachePath:nil
+                                                                                            identifier:nil
+                                                                                   currentTimeCallback:nil
+                                                                             defaultExpirationInterval:1
+                                                                              garbageCollectorInterval:1
+                                                                                                 debug:nil];
+    XCTAssertEqual(dataCacheOptions.gcIntervalSec,
                    SPTPersistentCacheMinimumGCIntervalLimit);
 }
 
 - (void)testMinimumDefaultExpirationInterval
 {
-    self.dataCacheOptions = [[SPTPersistentCacheOptions alloc] initWithCachePath:nil
-                                                                          identifier:nil
-                             
-                                                                 currentTimeCallback:nil
-                                                           defaultExpirationInterval:1
-                                                            garbageCollectorInterval:1
-                                                                               debug:nil];
-    XCTAssertEqual(self.dataCacheOptions.defaultExpirationPeriodSec,
+    SPTPersistentCacheOptions *dataCacheOptions = [[SPTPersistentCacheOptions alloc] initWithCachePath:nil
+                                                                                            identifier:nil
+                                                                                   currentTimeCallback:nil
+                                                                             defaultExpirationInterval:1
+                                                                              garbageCollectorInterval:1
+                                                                                                 debug:nil];
+    XCTAssertEqual(dataCacheOptions.defaultExpirationPeriodSec,
                    SPTPersistentCacheMinimumExpirationLimit);
 }
 

--- a/Tests/SPTPersistentCacheOptionsTests.m
+++ b/Tests/SPTPersistentCacheOptionsTests.m
@@ -21,6 +21,7 @@
 #import <XCTest/XCTest.h>
 
 #import <SPTPersistentCache/SPTPersistentCacheOptions.h>
+#import "SPTPersistentCacheObjectDescriptionStyleValidator.h"
 
 @interface SPTPersistentCacheOptionsTests : XCTestCase
 @property (nonatomic, strong) SPTPersistentCacheOptions *dataCacheOptions;
@@ -70,5 +71,40 @@
                    SPTPersistentCacheMinimumExpirationLimit);
 }
 
+#pragma mark Test describing objects
+
+- (void)testDescriptionAdheresToStyle
+{
+    SPTPersistentCacheObjectDescriptionStyleValidator *styleValidator = [SPTPersistentCacheObjectDescriptionStyleValidator new];
+
+    NSString * const description = self.dataCacheOptions.description;
+
+    XCTAssertTrue([styleValidator isValidStyleDescription:description], @"The description string should follow our style.");
+}
+
+- (void)testDescriptionContainsClassName
+{
+    NSString * const description = self.dataCacheOptions.description;
+
+    const NSRange classNameRange = [description rangeOfString:@"SPTPersistentCacheOptions"];
+    XCTAssertNotEqual(classNameRange.location, NSNotFound, @"The class name should exist in the description");
+}
+
+- (void)testDebugDescriptionAdheresToStyle
+{
+    SPTPersistentCacheObjectDescriptionStyleValidator *styleValidator = [SPTPersistentCacheObjectDescriptionStyleValidator new];
+
+    NSString * const debugDescription = self.dataCacheOptions.debugDescription;
+
+    XCTAssertTrue([styleValidator isValidStyleDescription:debugDescription], @"The debugDescription string should follow our style.");
+}
+
+- (void)testDebugDescriptionContainsClassName
+{
+    NSString * const debugDescription = self.dataCacheOptions.debugDescription;
+
+    const NSRange classNameRange = [debugDescription rangeOfString:@"SPTPersistentCacheOptions"];
+    XCTAssertNotEqual(classNameRange.location, NSNotFound, @"The class name should exist in the debugDescription");
+}
 
 @end

--- a/Tests/SPTPersistentCacheRecordTests.m
+++ b/Tests/SPTPersistentCacheRecordTests.m
@@ -22,6 +22,7 @@
 #import <XCTest/XCTest.h>
 #import "SPTPersistentCacheRecord.h"
 #import "SPTPersistentCacheRecord+Private.h"
+#import "SPTPersistentCacheObjectDescriptionStyleValidator.h"
 
 
 static const NSUInteger SPTPersistentCacheRecordTestRefCount = 43244555;
@@ -53,6 +54,42 @@ static NSString * const SPTPersistentCacheRecordTestDataString = @"https://spoti
     XCTAssertEqualObjects(self.dataCacheRecord.key, SPTPersistentCacheRecordTestKey);
     XCTAssertEqual(self.dataCacheRecord.refCount, SPTPersistentCacheRecordTestRefCount);
     XCTAssertEqual(self.dataCacheRecord.ttl, SPTPersistentCacheRecordTestTTL);
+}
+
+#pragma mark Test describing objects
+
+- (void)testDescriptionAdheresToStyle
+{
+    SPTPersistentCacheObjectDescriptionStyleValidator *styleValidator = [SPTPersistentCacheObjectDescriptionStyleValidator new];
+
+    NSString * const description = self.dataCacheRecord.description;
+
+    XCTAssertTrue([styleValidator isValidStyleDescription:description], @"The description string should follow our style.");
+}
+
+- (void)testDescriptionContainsClassName
+{
+    NSString * const description = self.dataCacheRecord.description;
+
+    const NSRange classNameRange = [description rangeOfString:@"SPTPersistentCacheRecord"];
+    XCTAssertNotEqual(classNameRange.location, NSNotFound, @"The class name should exist in the description");
+}
+
+- (void)testDebugDescriptionAdheresToStyle
+{
+    SPTPersistentCacheObjectDescriptionStyleValidator *styleValidator = [SPTPersistentCacheObjectDescriptionStyleValidator new];
+
+    NSString * const debugDescription = self.dataCacheRecord.debugDescription;
+
+    XCTAssertTrue([styleValidator isValidStyleDescription:debugDescription], @"The debugDescription string should follow our style.");
+}
+
+- (void)testDebugDescriptionContainsClassName
+{
+    NSString * const debugDescription = self.dataCacheRecord.debugDescription;
+
+    const NSRange classNameRange = [debugDescription rangeOfString:@"SPTPersistentCacheRecord"];
+    XCTAssertNotEqual(classNameRange.location, NSNotFound, @"The class name should exist in the debugDescription");
 }
 
 @end

--- a/Tests/SPTPersistentCacheResponseTests.m
+++ b/Tests/SPTPersistentCacheResponseTests.m
@@ -24,6 +24,7 @@
 #import <SPTPersistentCache/SPTPersistentCacheRecord.h>
 #import "SPTPersistentCacheResponse+Private.h"
 #import <SPTPersistentCache/SPTPersistentCacheResponse.h>
+#import "SPTPersistentCacheObjectDescriptionStyleValidator.h"
 
 
 static const SPTPersistentCacheResponseCode SPTPersistentCacheResponseTestsTestCode   = SPTPersistentCacheResponseCodeNotFound;
@@ -57,5 +58,33 @@ static const SPTPersistentCacheResponseCode SPTPersistentCacheResponseTestsTestC
     XCTAssertEqualObjects(self.persistentCacheResponse.error, self.testError);
     XCTAssertEqualObjects(self.persistentCacheResponse.record, self.testCacheRecord);
 }
+
+#pragma mark Test describing objects
+
+- (void)testDescriptionAdheresToStyle
+{
+    SPTPersistentCacheObjectDescriptionStyleValidator *styleValidator = [SPTPersistentCacheObjectDescriptionStyleValidator new];
+
+    NSString * const description = self.persistentCacheResponse.description;
+
+    XCTAssertTrue([styleValidator isValidStyleDescription:description], @"The description string should follow our style.");
+}
+
+- (void)testDescriptionContainsClassName
+{
+    NSString * const description = self.persistentCacheResponse.description;
+
+    const NSRange classNameRange = [description rangeOfString:@"SPTPersistentCacheResponse"];
+    XCTAssertNotEqual(classNameRange.location, NSNotFound, @"The class name should exist in the description");
+}
+
+- (void)testDebugDescriptionContainsClassName
+{
+    NSString * const debugDescription = self.persistentCacheResponse.debugDescription;
+
+    const NSRange classNameRange = [debugDescription rangeOfString:@"SPTPersistentCacheResponse"];
+    XCTAssertNotEqual(classNameRange.location, NSNotFound, @"The class name should exist in the debugDescription");
+}
+
 
 @end


### PR DESCRIPTION
This PR adds a few things. First a way to create consistent-looking description and debug description strings. Secondly, using this function, I’ve overridden the `-description` and `-debugDescription` methods for the following classes:
- `SPTPersistentCacheOptions`
- `SPTPersistentCacheRecord`
- `SPTPersistentCacheResponse`

There are tests for all of it. This PR also enables the tests for the record class (it wasn’t included in the test target).

The PR also fixes some more build issues with the framework targets I noticed while adding files to them.
