### PR TITLE
Remove space in SPTPersistentCacheResponse.h documentation

### DIFF
--- a/include/SPTPersistentCache/SPTPersistentCacheResponse.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheResponse.h
@@ -46,7 +46,6 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
 
 /**
  * @brief SPTPersistentCacheResponse
- *
  * @discussion Class defines one response passed in callback to call loadDataForKey:
  */
 @interface SPTPersistentCacheResponse : NSObject


### PR DESCRIPTION
- Only action that is needed for style of this header
