### PR TITLE
Fully qualify the posix wrapper header

### DIFF
--- a/Sources/SPTPersistentCachePosixWrapper.h
+++ b/Sources/SPTPersistentCachePosixWrapper.h
@@ -20,6 +20,8 @@
  */
 #import <Foundation/Foundation.h>
 
+#include <sys/stat.h>
+
 /**
  * An Obj-C wrapper for POSIX functions mainly made for mocking functions during unit tests.
  */

--- a/Sources/SPTPersistentCachePosixWrapper.m
+++ b/Sources/SPTPersistentCachePosixWrapper.m
@@ -20,8 +20,6 @@
  */
 #import "SPTPersistentCachePosixWrapper.h"
 
-#include <sys/stat.h>
-
 @implementation SPTPersistentCachePosixWrapper
 
 - (int)close:(int)descriptor


### PR DESCRIPTION
- We need the stat include in the header since we reference
  stat as a struct
