### PR TITLE
Podspec fixes

### DIFF
--- a/SPTPersistentCache.podspec
+++ b/SPTPersistentCache.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
     s.source       = { :git => "https://github.com/spotify/SPTPersistentCache.git", :tag => s.version }
     s.source_files = "include/SPTPersistentCache/*.h", "Sources/**/*.{h,m,c}"
     s.public_header_files = "include/SPTPersistentCache/*.h"
-    s.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+    s.xcconfig = { "OTHER_LDFLAGS" => "-lObjC" }
 
 end

--- a/SPTPersistentCache.podspec
+++ b/SPTPersistentCache.podspec
@@ -13,9 +13,12 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "7.0"
     s.osx.deployment_target = "10.8"
 
-    s.homepage     = "https://github.com/spotify/SPTPersistentCache"
-    s.license      = "Apache 2.0"
-    s.author       = { "Dmitry Ponomarev" => "dmitry@spotify.com" }
+    s.homepage          = "https://github.com/spotify/SPTPersistentCache"
+    s.social_media_url  = "https://twitter.com/spotifyeng"
+    s.license           = "Apache 2.0"
+    s.author            = {
+        "Dmitry Ponomarev" => "dmitry@spotify.com"
+    }
     s.source       = { :git => "https://github.com/spotify/SPTPersistentCache.git", :tag => s.version }
     s.source_files = "include/SPTPersistentCache/*.h", "Sources/**/*.{h,m,c}"
     s.public_header_files = "include/SPTPersistentCache/*.h"

--- a/SPTPersistentCache.podspec
+++ b/SPTPersistentCache.podspec
@@ -19,9 +19,12 @@ Pod::Spec.new do |s|
     s.author            = {
         "Dmitry Ponomarev" => "dmitry@spotify.com"
     }
-    s.source       = { :git => "https://github.com/spotify/SPTPersistentCache.git", :tag => s.version }
-    s.source_files = "include/SPTPersistentCache/*.h", "Sources/**/*.{h,m,c}"
-    s.public_header_files = "include/SPTPersistentCache/*.h"
-    s.xcconfig = { "OTHER_LDFLAGS" => "-lObjC" }
+
+    s.source                = { :git => "https://github.com/spotify/SPTPersistentCache.git", :tag => s.version }
+    s.source_files          = "include/SPTPersistentCache/*.h", "Sources/**/*.{h,m,c}"
+    s.public_header_files   = "include/SPTPersistentCache/*.h"
+    s.xcconfig              = {
+        "OTHER_LDFLAGS" => "-lObjC"
+    }
 
 end


### PR DESCRIPTION
- Adds a link to our [Spotify Engineering Twitter](http://twitter.com/spotifyeng) account.
- Re-formats the podspec making sure we use only one type of quote character. As well as some other small changes to the formatting.
