### PR TITLE
Bump Travis-CI OS X image to Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - master
     - /^release-.*$/
 
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: objective-c
 
 before_install: ./ci/before_install.sh


### PR DESCRIPTION
Time to start using Xcode 7.3 on the CI.

@spotify/objc-dev 
