### PR TITLE
Use extended file attributes to store the record header

### DIFF
--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		050076B31C7A4354000819B5 /* SPTPersistentCachePosixWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 050076B11C7A4354000819B5 /* SPTPersistentCachePosixWrapper.h */; };
 		050076B41C7A4354000819B5 /* SPTPersistentCachePosixWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 050076B21C7A4354000819B5 /* SPTPersistentCachePosixWrapper.m */; };
 		050076B51C7A4DC7000819B5 /* SPTPersistentCachePosixWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 050076B21C7A4354000819B5 /* SPTPersistentCachePosixWrapper.m */; };
+		5EB3C5EB1CEA1B900091739E /* NSError+SPTPersistentCacheDomainErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1D238C1C7785A900D0477A /* NSError+SPTPersistentCacheDomainErrors.h */; };
 		9C9E707B1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70791C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m */; };
 		9C9E707C1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C9E707A1C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.h */; };
 		9C9E707D1C790F3700E1CBE6 /* SPTPersistentCacheObjectDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9E70791C790F0B00E1CBE6 /* SPTPersistentCacheObjectDescription.m */; };
@@ -236,6 +237,7 @@
 				DD1D23851C77857E00D0477A /* SPTPersistentCache.h in Headers */,
 				DD1D23B51C7785AE00D0477A /* SPTPersistentCache+Private.h in Headers */,
 				DD1D23BB1C7785AE00D0477A /* SPTPersistentCacheRecord+Private.h in Headers */,
+				5EB3C5EB1CEA1B900091739E /* NSError+SPTPersistentCacheDomainErrors.h in Headers */,
 				DD1D23B31C7785AE00D0477A /* crc32iso3309.h in Headers */,
 				DD1D23BD1C7785AE00D0477A /* SPTPersistentCacheResponse+Private.h in Headers */,
 				C4EA65071C7A547000A6091A /* SPTPersistentCacheDebugUtilities.h in Headers */,

--- a/Tests/SPTPersistentCacheHeaderTests.m
+++ b/Tests/SPTPersistentCacheHeaderTests.m
@@ -24,6 +24,8 @@
 #import <SPTPersistentCache/SPTPersistentCache.h>
 #import "SPTPersistentCacheTypeUtilities.h"
 
+static NSString* const SPTCacheRecordFileName = @"cache.record";
+
 
 @interface SPTPersistentCacheHeaderTests : XCTestCase
 
@@ -99,6 +101,140 @@
     XCTAssertEqual(header.payloadSizeBytes, payloadSize);
     XCTAssertEqual(header.updateTimeSec, updateTime);
     XCTAssertEqual(header.crc, SPTPersistentCacheCalculateHeaderCRC(&header));
+}
+
+- (void)testSPTPersistentCacheGetHeaderFromFileWithPath
+{
+    // GIVEN
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:SPTCacheRecordFileName];
+    [self removeFileAtPath:filePath];
+    SPTPersistentCacheRecordHeader header = [self dummyHeader];
+    XCTAssertNil([self createRecordAtPath:filePath withHeader:&header]);
+
+    // WHEN
+    SPTPersistentCacheRecordHeader loadedHeader;
+    NSError* error = SPTPersistentCacheGetHeaderFromFileWithPath(filePath, &loadedHeader);
+
+    // THEN
+    XCTAssertNil(error);
+    XCTAssertEqual(header.reserved1, loadedHeader.reserved1);
+    XCTAssertEqual(header.reserved2, loadedHeader.reserved2);
+    XCTAssertEqual(header.reserved3, loadedHeader.reserved3);
+    XCTAssertEqual(header.reserved4, loadedHeader.reserved4);
+    XCTAssertEqual(header.flags, loadedHeader.flags);
+    XCTAssertEqual(header.magic, loadedHeader.magic);
+    XCTAssertEqual(header.headerSize, loadedHeader.headerSize);
+    XCTAssertEqual(header.refCount, loadedHeader.refCount);
+    XCTAssertEqual(header.ttl, loadedHeader.ttl);
+    XCTAssertEqual(header.payloadSizeBytes, loadedHeader.payloadSizeBytes);
+    XCTAssertEqual(header.updateTimeSec, loadedHeader.updateTimeSec);
+    XCTAssertEqual(header.crc, loadedHeader.crc);
+
+    [self removeFileAtPath:filePath];
+}
+
+- (void)testSPTPersistentCacheGetHeaderFromFileWithPathFailsWithError
+{
+    // GIVEN
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:SPTCacheRecordFileName];
+
+    // WHEN
+    SPTPersistentCacheRecordHeader loadedHeader;
+    NSError* error = SPTPersistentCacheGetHeaderFromFileWithPath(filePath, &loadedHeader);
+
+    // THEN
+    XCTAssertNotNil(error);
+}
+
+- (void)testSPTPersistentCacheGetHeaderFromFileWithPathLegacy
+{
+    // GIVEN
+    SPTPersistentCacheRecordHeader legacyHeader = [self dummyHeader];
+    NSData* payload = [[NSMutableData dataWithLength:legacyHeader.payloadSizeBytes] copy];
+    NSMutableData* rawData = [NSMutableData dataWithBytes:&legacyHeader length:SPTPersistentCacheRecordHeaderSize];
+    [rawData appendData:payload];
+    // create a record with legacy header (saved to the file with a payload).
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:SPTCacheRecordFileName];
+    [self removeFileAtPath:filePath];
+    XCTAssertTrue([[NSFileManager defaultManager] createFileAtPath:filePath contents:rawData attributes:nil]);
+
+    // WHEN
+    SPTPersistentCacheRecordHeader loadedHeader;
+    NSError* error = SPTPersistentCacheGetHeaderFromFileWithPath(filePath, &loadedHeader);
+
+    // THEN
+    XCTAssertNil(error);
+    XCTAssertEqual(legacyHeader.reserved1, loadedHeader.reserved1);
+    XCTAssertEqual(legacyHeader.reserved2, loadedHeader.reserved2);
+    XCTAssertEqual(legacyHeader.reserved3, loadedHeader.reserved3);
+    XCTAssertEqual(legacyHeader.reserved4, loadedHeader.reserved4);
+    XCTAssertEqual(legacyHeader.flags, loadedHeader.flags);
+    XCTAssertEqual(legacyHeader.magic, loadedHeader.magic);
+    XCTAssertEqual(legacyHeader.headerSize, loadedHeader.headerSize);
+    XCTAssertEqual(legacyHeader.refCount, loadedHeader.refCount);
+    XCTAssertEqual(legacyHeader.ttl, loadedHeader.ttl);
+    XCTAssertEqual(legacyHeader.payloadSizeBytes, loadedHeader.payloadSizeBytes);
+    XCTAssertEqual(legacyHeader.updateTimeSec, loadedHeader.updateTimeSec);
+    XCTAssertEqual(legacyHeader.crc, loadedHeader.crc);
+
+    [self removeFileAtPath:filePath];
+}
+
+- (void)testSPTPersistentCacheSetHeaderForFileWithPath
+{
+    // GIVEN
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:SPTCacheRecordFileName];
+    [self removeFileAtPath:filePath];
+    SPTPersistentCacheRecordHeader header = [self dummyHeader];
+
+    // WHEN
+    NSError* error = [self createRecordAtPath:filePath withHeader:&header];
+
+    // THEN
+    XCTAssertNil(error);
+
+    [self removeFileAtPath:filePath];
+}
+
+- (void)testSPTPersistentCacheSetHeaderForFileWithPathFailsWithError
+{
+    // GIVEN
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:SPTCacheRecordFileName];
+
+    // WHEN
+    SPTPersistentCacheRecordHeader loadedHeader;
+    NSError* error = SPTPersistentCacheSetHeaderForFileWithPath(filePath, &loadedHeader);
+
+    // THEN
+    XCTAssertNotNil(error);
+}
+
+#pragma mark - Private
+
+- (NSError*)createRecordAtPath:(NSString*)filePath withHeader:(SPTPersistentCacheRecordHeader*)header
+{
+    NSMutableData* data = [NSMutableData dataWithLength:header->payloadSizeBytes];
+
+    XCTAssertTrue([[NSFileManager defaultManager] createFileAtPath:filePath contents:data attributes:nil]);
+    return SPTPersistentCacheSetHeaderForFileWithPath(filePath, header);
+}
+
+- (void)removeFileAtPath:(NSString*)filePath
+{
+    if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        NSError* error = nil;
+        [[NSFileManager defaultManager] removeItemAtPath:filePath error:&error];
+        XCTAssertNil(error);
+    }
+}
+
+- (SPTPersistentCacheRecordHeader)dummyHeader {
+    uint64_t ttl = 64;
+    uint64_t payloadSize = 400;
+    uint64_t updateTime = spt_uint64rint([[NSDate date] timeIntervalSince1970]);
+    BOOL isLocked = YES;
+
+    return SPTPersistentCacheRecordHeaderMake(ttl, payloadSize, updateTime, isLocked);
 }
 
 @end

--- a/include/SPTPersistentCache/SPTPersistentCache.h
+++ b/include/SPTPersistentCache/SPTPersistentCache.h
@@ -74,6 +74,10 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheLoadingError) {
      */
     SPTPersistentCacheLoadingErrorRecordIsStreamAndBusy,
     /**
+     * The file attribute operation(read or write) failed.
+     */
+    SPTPersistentCacheLoadingErrorFileAttributeOperationFail,
+    /**
      * Something bad has happened that shouldn't.
      */
     SPTPersistentCacheLoadingErrorInternalInconsistency

--- a/include/SPTPersistentCache/SPTPersistentCacheHeader.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheHeader.h
@@ -81,6 +81,17 @@ FOUNDATION_EXPORT SPTPersistentCacheRecordHeader SPTPersistentCacheRecordHeaderM
  */
 FOUNDATION_EXPORT SPTPersistentCacheRecordHeader *SPTPersistentCacheGetHeaderFromData(void *data, size_t size);
 /**
+ * Function loads a header from a given file.
+ * @return nil if everything is ok, NSError object otherwise.
+ */
+FOUNDATION_EXPORT NSError* SPTPersistentCacheGetHeaderFromFileWithPath(NSString *filepath, SPTPersistentCacheRecordHeader *header);
+/**
+ * Function saves a header to a given file.
+ * @return nil if everything is ok, NSError object otherwise.
+ */
+FOUNDATION_EXPORT NSError* SPTPersistentCacheSetHeaderForFileWithPath(NSString *filepath, const SPTPersistentCacheRecordHeader *header);
+
+/**
  * Function validates header accoring to predefined rules used in production code.
  * @return -1 if everything is ok, otherwise one of codes from SPTPersistentCacheLoadingError.
  */


### PR DESCRIPTION
Changed the cache to use extended file attributes as a storage for cache record header. Here is the original [proposal](https://github.com/spotify/SPTPersistentCache/issues/64).

**Concerns.** The current solution is not generic & extendable enough. Means, it doesn't support versioning and migration between the versions. By adding a new field to the `SPTPersistentCacheRecordHeader` struct, you have to provide the way to migrate from obsolete header.
