### PR TITLE
Fix incorrect nullability of `SPTPersistentCacheOptions`

### DIFF
--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -128,7 +128,7 @@
 		698B70631C7538B000BDBFEA /* fc22d4f65c1ba875f6bb5ba7d35a7fd12851ed5c */ = {isa = PBXFileReference; lastKnownFileType = file; path = fc22d4f65c1ba875f6bb5ba7d35a7fd12851ed5c; sourceTree = "<group>"; };
 		772B8BF01D6DE879008E7347 /* SPTPersistentCachePerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCachePerformanceTests.m; sourceTree = "<group>"; };
 		9C882A801C65422700D463BB /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
-		9C882A811C65422700D463BB /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
+		9C882A811C65422700D463BB /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = spotify_os.xcconfig; path = ci/spotify_os.xcconfig; sourceTree = "<group>"; };
 		9C96612C1CC0FC7B00E6F04D /* SPTPersistentCacheFileManager+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPTPersistentCacheFileManager+Private.h"; sourceTree = "<group>"; };
 		9C9E706F1C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTPersistentCacheObjectDescription.h; sourceTree = "<group>"; };
 		9C9E70701C78D39900E1CBE6 /* SPTPersistentCacheObjectDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTPersistentCacheObjectDescription.m; sourceTree = "<group>"; };
@@ -207,22 +207,22 @@
 		0510FF221BA2FF7A00ED0766 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				050076A71C7A2B57000819B5 /* Mocks */,
+				698B70521C7538B000BDBFEA /* Resources */,
+				0510FF231BA2FF7A00ED0766 /* Supporting Files */,
 				C413BA061C71E2DC002D41FB /* NSError+SPTPersistentCacheDomainErrorsTests.m */,
+				C4B98D1A1C7B5CB900E1B9A3 /* SPTPersistentCacheDebugUtilitiesTests.m */,
 				C48AE7401C75BB8300814D7D /* SPTPersistentCacheFileManagerTests.m */,
+				C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheGarbageCollectorTests.m */,
 				C413BA001C71CBBA002D41FB /* SPTPersistentCacheHeaderTests.m */,
 				9C9E70741C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.h */,
 				9C9E70751C78FD9700E1CBE6 /* SPTPersistentCacheObjectDescriptionStyleValidator.m */,
 				9C9E70721C78D5AA00E1CBE6 /* SPTPersistentCacheObjectDescriptionTests.m */,
 				C4B414901C6A24A10099FECD /* SPTPersistentCacheOptionsTests.m */,
+				772B8BF01D6DE879008E7347 /* SPTPersistentCachePerformanceTests.m */,
 				C4B4148B1C6A01970099FECD /* SPTPersistentCacheRecordTests.m */,
 				C4B4148E1C6A1BED0099FECD /* SPTPersistentCacheResponseTests.m */,
 				0510FF6A1BA3073D00ED0766 /* SPTPersistentCacheTests.m */,
-				C41237071C6A29FB00C1E9B8 /* SPTPersistentCacheGarbageCollectorTests.m */,
-				C4B98D1A1C7B5CB900E1B9A3 /* SPTPersistentCacheDebugUtilitiesTests.m */,
-				772B8BF01D6DE879008E7347 /* SPTPersistentCachePerformanceTests.m */,
-				050076A71C7A2B57000819B5 /* Mocks */,
-				698B70521C7538B000BDBFEA /* Resources */,
-				0510FF231BA2FF7A00ED0766 /* Supporting Files */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -557,6 +557,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SPT_PC_NON_ERROR_WARNINGS_0720 = "";
 				SPT_PC_NON_ERROR_WARNINGS_0730 = "$(SPT_PC_NON_ERROR_WARNING_0720) -Wno-error=partial-availability";
+				SPT_PC_NON_ERROR_WARNINGS_0800 = "$(SPT_PC_NON_ERROR_WARNINGS_0730)";
+				SPT_PC_NON_ERROR_WARNINGS_0810 = "$(SPT_PC_NON_ERROR_WARNINGS_0800)";
+				SPT_PC_NON_ERROR_WARNINGS_0820 = "$(SPT_PC_NON_ERROR_WARNINGS_0810)";
+				SPT_PC_NON_ERROR_WARNINGS_0830 = "$(SPT_PC_NON_ERROR_WARNINGS_0820)";
 				WARNING_CFLAGS = (
 					"$(inherited)",
 					"$(SPT_PC_NON_ERROR_WARNINGS_$(XCODE_VERSION_MINOR))",
@@ -584,6 +588,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SPT_PC_NON_ERROR_WARNINGS_0720 = "";
 				SPT_PC_NON_ERROR_WARNINGS_0730 = "$(SPT_PC_NON_ERROR_WARNING_0720) -Wno-error=partial-availability";
+				SPT_PC_NON_ERROR_WARNINGS_0800 = "$(SPT_PC_NON_ERROR_WARNINGS_0730)";
+				SPT_PC_NON_ERROR_WARNINGS_0810 = "$(SPT_PC_NON_ERROR_WARNINGS_0800)";
+				SPT_PC_NON_ERROR_WARNINGS_0820 = "$(SPT_PC_NON_ERROR_WARNINGS_0810)";
+				SPT_PC_NON_ERROR_WARNINGS_0830 = "$(SPT_PC_NON_ERROR_WARNINGS_0820)";
 				WARNING_CFLAGS = (
 					"$(inherited)",
 					"$(SPT_PC_NON_ERROR_WARNINGS_$(XCODE_VERSION_MINOR))",

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/xcshareddata/xcschemes/SPTPersistentCacheDemo.xcscheme
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo.xcodeproj/xcshareddata/xcschemes/SPTPersistentCacheDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo/DetailViewController.m
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo/DetailViewController.m
@@ -52,7 +52,8 @@
                                             NSLog(@"Failed: %@", response.error);
                                             return;
                                         }
-                                        self.detailImageView.image = [UIImage imageWithData:response.record.data];
+                                        NSData *imageData = response.record.data;
+                                        self.detailImageView.image = [UIImage imageWithData:imageData];
                                     }
                                          onQueue:dispatch_get_main_queue()];
     }

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -294,7 +294,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SPTPersistentCache;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Spotify;
 				TargetAttributes = {
 					0520219B1C737DBE003A4FB4 = {

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-OSX.xcscheme
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-iOS.xcscheme
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/SPTPersistentCachePerformanceTests.m
+++ b/Tests/SPTPersistentCachePerformanceTests.m
@@ -111,7 +111,7 @@ static const int SPTPersistentCachePerformanceIterationCount = 200;
 
     self.unLockTimings = [NSMutableArray arrayWithCapacity:SPTPersistentCachePerformanceIterationCount];
     self.readTimings = [NSMutableArray arrayWithCapacity:SPTPersistentCachePerformanceIterationCount];
-    for (int i = 0; i < SPTPersistentCachePerformanceIterationCount; i++) {
+    for (NSUInteger i = 0; i < SPTPersistentCachePerformanceIterationCount; i++) {
         self.unLockTimings[i] = (SPTPersistentCacheTiming *)[NSNull null];
         self.readTimings[i] = (SPTPersistentCacheTiming *)[NSNull null];
     }

--- a/Tests/SPTPersistentCacheTests.m
+++ b/Tests/SPTPersistentCacheTests.m
@@ -287,7 +287,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
 
             if (response.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                 XCTAssertNotNil(response.record, @"Expected valid not nil record");
-                ImageClass *image = [[ImageClass alloc] initWithData:response.record.data];
+                ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)response.record.data];
                 XCTAssertNotNil(image, @"Expected valid not nil image");
                 XCTAssertNil(response.error, @"error is not expected to be here");
 
@@ -364,7 +364,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
 
         if (response.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
             XCTAssertNotNil(response.record, @"Expected valid not nil record");
-            ImageClass *image = [[ImageClass alloc] initWithData:response.record.data];
+            ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)response.record.data];
             XCTAssertNotNil(image, @"Expected valid not nil image");
             XCTAssertNil(response.error, @"error is not expected to be here");
 
@@ -500,7 +500,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
 
             if (response.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                 XCTAssertNotNil(response.record, @"Expected valid not nil record");
-                ImageClass *image = [[ImageClass alloc] initWithData:response.record.data];
+                ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)response.record.data];
                 XCTAssertNotNil(image, @"Expected valid not nil image");
                 XCTAssertNil(response.error, @"error is not expected to be here");
 
@@ -673,7 +673,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
 
                 if (loadResponse.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                     XCTAssertNotNil(loadResponse.record, @"Expected valid not nil record");
-                    ImageClass *image = [[ImageClass alloc] initWithData:loadResponse.record.data];
+                    ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)loadResponse.record.data];
                     XCTAssertNotNil(image, @"Expected valid not nil image");
                     XCTAssertNil(loadResponse.error, @"error is not expected to be here");
 
@@ -750,7 +750,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
 
                 if (loadResponse.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                     XCTAssertNotNil(loadResponse.record, @"Expected valid not nil record");
-                    ImageClass *image = [[ImageClass alloc] initWithData:loadResponse.record.data];
+                    ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)loadResponse.record.data];
                     XCTAssertNotNil(image, @"Expected valid not nil image");
                     XCTAssertNil(loadResponse.error, @"error is not expected to be here");
 
@@ -899,7 +899,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
             if (response.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                 ++successCalls;
                 XCTAssertNotNil(response.record, @"Expected valid not nil record");
-                ImageClass *image = [[ImageClass alloc] initWithData:response.record.data];
+                ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)response.record.data];
                 XCTAssertNotNil(image, @"Expected valid not nil image");
                 XCTAssertNil(response.error, @"error is not expected to be here");
 
@@ -963,7 +963,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
             if (response.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                 ++successCalls;
                 XCTAssertNotNil(response.record, @"Expected valid not nil record");
-                ImageClass *image = [[ImageClass alloc] initWithData:response.record.data];
+                ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)response.record.data];
                 XCTAssertNotNil(image, @"Expected valid not nil image");
                 XCTAssertNil(response.error, @"error is not expected to be here");
 
@@ -1055,7 +1055,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
             if (response.result == SPTPersistentCacheResponseCodeOperationSucceeded) {
                 ++successCalls;
                 XCTAssertNotNil(response.record, @"Expected valid not nil record");
-                ImageClass *image = [[ImageClass alloc] initWithData:response.record.data];
+                ImageClass *image = [[ImageClass alloc] initWithData:(NSData *)response.record.data];
                 XCTAssertNotNil(image, @"Expected valid not nil image");
                 XCTAssertNil(response.error, @"error is not expected to be here");
 

--- a/Viewer/SPTPersistentCacheViewer.xcodeproj/xcshareddata/xcschemes/SPTPersistentCacheViewer.xcscheme
+++ b/Viewer/SPTPersistentCacheViewer.xcodeproj/xcshareddata/xcschemes/SPTPersistentCacheViewer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/include/SPTPersistentCache/SPTPersistentCacheOptions.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheOptions.h
@@ -231,19 +231,19 @@ FOUNDATION_EXPORT const NSUInteger SPTPersistentCacheMinimumExpirationLimit;
 
 /**
  *  Compatibility alias for `useDirectorySeparation`.
- *  @see useDirectorySeparation
+ *  @seealso useDirectorySeparation
  */
 @property (nonatomic, assign) BOOL folderSeparationEnabled DEPRECATED_MSG_ATTRIBUTE("Use the useDirectorySeparation property instead");
 /**
  *  Compatibility alias for `garbageCollectionInterval`.
  *  @deprecated
- *  @see garbageCollectionInterval
+ *  @seealso garbageCollectionInterval
  */
 @property (nonatomic, assign, readonly) NSUInteger gcIntervalSec DEPRECATED_MSG_ATTRIBUTE("Use the garbageCollectionInterval property instead");
 /**
  *  Compatibility alias for `defaultExpirationPeriod`.
  *  @deprecated
- *  @see defaultExpirationPeriod
+ *  @seealso defaultExpirationPeriod
  */
 @property (nonatomic, assign, readonly) NSUInteger defaultExpirationPeriodSec DEPRECATED_MSG_ATTRIBUTE("Use the defaultExpirationPeriod property instead");
 

--- a/include/SPTPersistentCache/SPTPersistentCacheRecord.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheRecord.h
@@ -26,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief SPTPersistentCacheRecord
  * @discussion Class defines one record in cache that is returned in response.
  *             Each record is represented by single file on disk.
- *             If file deleted from disk then cache assumes its never existed and return SPTPersistentCacheResponseCodeNotFound for load call.
+ *             If file deleted from disk then cache assumes its never existed and return 
+ *             `SPTPersistentCacheResponseCodeNotFound` for load call.
  */
 @interface SPTPersistentCacheRecord : NSObject
 

--- a/include/SPTPersistentCache/SPTPersistentCacheResponse.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheResponse.h
@@ -53,6 +53,7 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
 @interface SPTPersistentCacheResponse : NSObject
 
 /**
+ * The result of the cache request.
  * @seealso SPTPersistentCacheResponseCode
  */
 @property (nonatomic, assign, readonly) SPTPersistentCacheResponseCode result;

--- a/include/SPTPersistentCache/SPTPersistentCacheResponse.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheResponse.h
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
 @interface SPTPersistentCacheResponse : NSObject
 
 /**
- * @see SPTPersistentCacheResponseCode
+ * @seealso SPTPersistentCacheResponseCode
  */
 @property (nonatomic, assign, readonly) SPTPersistentCacheResponseCode result;
 /**
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
 @property (nonatomic, strong, readonly, nullable) NSError *error;
 /**
  * The record of the cached data, if found.
- * @see SPTPersistentCacheRecord
+ * @seealso SPTPersistentCacheRecord
  */
 @property (nonatomic, strong, readonly, nullable) SPTPersistentCacheRecord *record;
 

--- a/include/SPTPersistentCache/SPTPersistentCacheResponse.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheResponse.h
@@ -58,7 +58,7 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
  */
 @property (nonatomic, assign, readonly) SPTPersistentCacheResponseCode result;
 /**
- * Defines error of response, if appliable.
+ * Defines error of response, if applicable.
  */
 @property (nonatomic, strong, readonly, nullable) NSError *error;
 /**

--- a/include/SPTPersistentCache/SPTPersistentCacheResponse.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheResponse.h
@@ -57,13 +57,14 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
  */
 @property (nonatomic, assign, readonly) SPTPersistentCacheResponseCode result;
 /**
- * Defines error of response if appliable
+ * Defines error of response, if appliable.
  */
-@property (nonatomic, strong, readonly) NSError *error;
+@property (nonatomic, strong, readonly, nullable) NSError *error;
 /**
+ * The record of the cached data, if found.
  * @see SPTPersistentCacheRecord
  */
-@property (nonatomic, strong, readonly) SPTPersistentCacheRecord *record;
+@property (nonatomic, strong, readonly, nullable) SPTPersistentCacheRecord *record;
 
 @end
 


### PR DESCRIPTION
This PR fixes the nullability issue identified in #86.

It also bumps Xcode’s `LastUpgradeVersion` to 8.2 and fixes some minor issues with the API documentation.

@spotify/objc-dev 