### PR TITLE
Tweaks to garbage collection

### DIFF
--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -508,6 +508,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				VALID_ARCHS = "armv7 arm64 armv7k";
 			};
 			name = Debug;
 		};
@@ -528,6 +529,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "armv7 arm64 armv7k";
 			};
 			name = Release;
 		};

--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -535,6 +535,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SPTPersistentCache;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Spotify;
 				TargetAttributes = {
 					0510FF121BA2FF7A00ED0766 = {
@@ -492,7 +492,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C882A801C65422700D463BB /* project.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
@@ -500,6 +503,7 @@
 					"$(inherited)",
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -507,6 +511,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C882A801C65422700D463BB /* project.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				HEADER_SEARCH_PATHS = (
 					include,

--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SPTPersistentCache;
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = Spotify;
 				TargetAttributes = {
 					0510FF121BA2FF7A00ED0766 = {
@@ -492,7 +492,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C882A801C65422700D463BB /* project.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -511,7 +515,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C882A801C65422700D463BB /* project.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				HEADER_SEARCH_PATHS = (

--- a/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
+++ b/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
+++ b/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
+++ b/SPTPersistentCache.xcodeproj/xcshareddata/xcschemes/SPTPersistentCache.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -74,6 +75,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -1048,7 +1048,8 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
                 NSNumber *fsize = [NSNumber numberWithLongLong:fileStat.st_size];
                 NSDictionary *values = @{NSFileModificationDate : mdate, NSFileSize: fsize};
 
-                [images addObject:@{ SPTDataCacheFileNameKey : [NSString stringWithUTF8String:[theURL fileSystemRepresentation]],
+                NSString *cacheFilename = [NSString stringWithUTF8String:[theURL fileSystemRepresentation]];
+                [images addObject:@{ SPTDataCacheFileNameKey : cacheFilename,
                                      SPTDataCacheFileAttributesKey : values }];
             }
         } else {

--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -391,6 +391,11 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
     [self.garbageCollector unschedule];
 }
 
+- (void)enqueueGarbageCollector
+{
+    [self.garbageCollector enqueueGarbageCollection];
+}
+
 - (void)pruneWithCallback:(SPTPersistentCacheResponseCallback _Nullable)callback
                   onQueue:(dispatch_queue_t _Nullable)queue
 {

--- a/Sources/SPTPersistentCacheFileManager.m
+++ b/Sources/SPTPersistentCacheFileManager.m
@@ -22,8 +22,6 @@
 #import "SPTPersistentCacheDebugUtilities.h"
 #import "SPTPersistentCacheOptions.h"
 
-static const double SPTPersistentCacheFileManagerMinFreeDiskSpace = 0.1;
-
 const NSUInteger SPTPersistentCacheFileManagerSubDirNameLength = 2;
 
 @implementation SPTPersistentCacheFileManager
@@ -179,7 +177,7 @@ const NSUInteger SPTPersistentCacheFileManagerSubDirNameLength = 2;
         SPTPersistentCacheDiskSize totalSpace = fileSystemSize.longLongValue;
         SPTPersistentCacheDiskSize freeSpace = fileSystemFreeSpace.longLongValue + currentCacheSize;
         SPTPersistentCacheDiskSize proposedCacheSize = freeSpace - llrint(totalSpace *
-                                                                              SPTPersistentCacheFileManagerMinFreeDiskSpace);
+                                                                              self.options.minimumFreeDiskSpaceFraction);
         
         tempCacheSize = MAX(0, proposedCacheSize);
         

--- a/Sources/SPTPersistentCacheGarbageCollector.h
+++ b/Sources/SPTPersistentCacheGarbageCollector.h
@@ -68,4 +68,9 @@
  */
 - (void)unschedule;
 
+/**
+ *  Enqueues the garbage collector. Called automatically if scheduled by the above functions.
+ */
+- (void)enqueueGarbageCollection;
+
 @end

--- a/Sources/SPTPersistentCacheGarbageCollector.m
+++ b/Sources/SPTPersistentCacheGarbageCollector.m
@@ -61,7 +61,7 @@ static const NSTimeInterval SPTPersistentCacheGarbageCollectorSchedulerTimerTole
 
 #pragma mark -
 
-- (void)enqueueGarbageCollection:(NSTimer *)timer
+- (void)enqueueGarbageCollection
 {
     __weak __typeof(self) const weakSelf = self;
     NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
@@ -79,6 +79,11 @@ static const NSTimeInterval SPTPersistentCacheGarbageCollectorSchedulerTimerTole
     operation.queuePriority = self.options.garbageCollectionPriority;
     operation.qualityOfService = self.options.garbageCollectionQualityOfService;
     [self.queue addOperation:operation];
+}
+
+- (void)garbageCollectionTimerFired:(NSTimer *)timer
+{
+    [self enqueueGarbageCollection];
 }
 
 - (void)schedule
@@ -100,7 +105,7 @@ static const NSTimeInterval SPTPersistentCacheGarbageCollectorSchedulerTimerTole
 
     self.timer = [NSTimer timerWithTimeInterval:self.options.garbageCollectionInterval
                                          target:self
-                                       selector:@selector(enqueueGarbageCollection:)
+                                       selector:@selector(garbageCollectionTimerFired:)
                                        userInfo:nil
                                         repeats:YES];
     

--- a/Sources/SPTPersistentCacheOptions.m
+++ b/Sources/SPTPersistentCacheOptions.m
@@ -27,6 +27,7 @@
 const NSUInteger SPTPersistentCacheDefaultExpirationTimeSec = 10 * 60;
 const NSUInteger SPTPersistentCacheDefaultGCIntervalSec = 6 * 60 + 3;
 const NSUInteger SPTPersistentCacheDefaultCacheSizeInBytes = 0; // unbounded
+const double SPTPersistentCacheDefaultMinFreeDiskSpaceFraction = 0.1; // 10% of total disk size
 
 const NSUInteger SPTPersistentCacheMinimumGCIntervalLimit = 60;
 const NSUInteger SPTPersistentCacheMinimumExpirationLimit = 60;
@@ -55,6 +56,7 @@ static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger m
         _garbageCollectionInterval = SPTPersistentCacheDefaultGCIntervalSec;
         _defaultExpirationPeriod = SPTPersistentCacheDefaultExpirationTimeSec;
         _sizeConstraintBytes = SPTPersistentCacheDefaultCacheSizeInBytes;
+        _minimumFreeDiskSpaceFraction = SPTPersistentCacheDefaultMinFreeDiskSpaceFraction;
         _maxConcurrentOperations = NSOperationQueueDefaultMaxConcurrentOperationCount;
         _writePriority = NSOperationQueuePriorityNormal;
         _writeQualityOfService = NSQualityOfServiceDefault;
@@ -117,6 +119,7 @@ static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger m
     copy.garbageCollectionInterval = self.garbageCollectionInterval;
     copy.defaultExpirationPeriod = self.defaultExpirationPeriod;
     copy.sizeConstraintBytes = self.sizeConstraintBytes;
+    copy.minimumFreeDiskSpaceFraction = self.minimumFreeDiskSpaceFraction;
 
     copy.debugOutput = self.debugOutput;
     copy.timingCallback = self.timingCallback;

--- a/Tests/SPTPersistentCacheGarbageCollectorTests.m
+++ b/Tests/SPTPersistentCacheGarbageCollectorTests.m
@@ -25,7 +25,7 @@
 
 @interface SPTPersistentCacheGarbageCollector ()
 @property (nonatomic, strong) NSTimer *timer;
-- (void)enqueueGarbageCollection:(NSTimer *)timer;
+- (void)garbageCollectionTimerFired:(NSTimer *)timer;
 @end
     
 
@@ -97,8 +97,25 @@
     dataCacheForUnitTests.queue = self.garbageCollector.queue;
 
     dataCacheForUnitTests.testExpectation = expectation;
-    [self.garbageCollector enqueueGarbageCollection:nil];
+    [self.garbageCollector enqueueGarbageCollection];
     
+    [self waitForExpectationsWithTimeout:1.0 handler:^(NSError * _Nullable error) {
+        XCTAssertTrue(dataCacheForUnitTests.wasRunRegularGCCalled);
+        XCTAssertTrue(dataCacheForUnitTests.wasPruneBySizeCalled);
+        XCTAssertFalse(dataCacheForUnitTests.wasCalledFromIncorrectQueue);
+    }];
+}
+
+- (void)testGarbageCollectorTimerFired
+{
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testGarbageCollectorEnqueue"];
+
+    SPTPersistentCacheForTimerProxyUnitTests *dataCacheForUnitTests = (SPTPersistentCacheForTimerProxyUnitTests *)self.garbageCollector.cache;
+    dataCacheForUnitTests.queue = self.garbageCollector.queue;
+
+    dataCacheForUnitTests.testExpectation = expectation;
+    [self.garbageCollector garbageCollectionTimerFired:nil];
+
     [self waitForExpectationsWithTimeout:1.0 handler:^(NSError * _Nullable error) {
         XCTAssertTrue(dataCacheForUnitTests.wasRunRegularGCCalled);
         XCTAssertTrue(dataCacheForUnitTests.wasPruneBySizeCalled);

--- a/Tests/SPTPersistentCacheTests.m
+++ b/Tests/SPTPersistentCacheTests.m
@@ -871,6 +871,18 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
     XCTAssertFalse(cache.garbageCollector.isGarbageCollectionScheduled);
 }
 
+- (void)testEnqueueGargabeCollection
+{
+    SPTPersistentCache *cache = [self createCacheWithTimeCallback:^NSTimeInterval{
+        // Exceed expiration interval by 1 sec
+        return kTestEpochTime + SPTPersistentCacheDefaultExpirationTimeSec + 1;
+    }
+                                                   expirationTime:SPTPersistentCacheDefaultExpirationTimeSec];
+
+    [cache.garbageCollector enqueueGarbageCollection];
+    XCTAssertFalse(cache.garbageCollector.isGarbageCollectionScheduled);
+}
+
 /**
  * This test also checks Req.#1.2 of cache API.
  */

--- a/include/SPTPersistentCache/SPTPersistentCache.h
+++ b/include/SPTPersistentCache/SPTPersistentCache.h
@@ -230,6 +230,11 @@ typedef NSString * _Nonnull(^SPTPersistentCacheChooseKeyCallback)(NSArray<NSStri
  */
 - (void)unscheduleGarbageCollector;
 /**
+ * Run the garbage collector right now. Use this if scheduling isn't appropriate,
+ * for example in applicationWillResignActive:
+ */
+- (void)enqueueGarbageCollector;
+/**
  * Delete all files files in managed folder unconditionaly.
  * @param callback May be nil if not interested in result.
  * @param queue Queue on which to run the callback. If callback is nil this is ignored otherwise mustn't be nil.

--- a/include/SPTPersistentCache/SPTPersistentCacheOptions.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheOptions.h
@@ -179,6 +179,13 @@ FOUNDATION_EXPORT const NSUInteger SPTPersistentCacheMinimumExpirationLimit;
  */
 @property (nonatomic, assign) NSUInteger sizeConstraintBytes;
 /**
+ *  The minimum fraction of free disk space required for caching. If there is less disk space
+ *  available than this, the cache will be purged during garbage collection until the treshold
+ *  is met. This could mean that the whole cache is evicted if the device is low on space.
+ *  @note Defaults to `0.1`, 10% of the total disk size.
+ */
+@property (nonatomic, assign) double minimumFreeDiskSpaceFraction;
+/**
  * The queue priority for garbage collection. Defaults to NSOperationQueuePriorityLow.
  */
 @property (nonatomic) NSOperationQueuePriority garbageCollectionPriority;


### PR DESCRIPTION
- Expose `enqueueGarbageCollection`
Scheduling garbage collection by time isn't appropriate for short-lived applications. This adds an alternative API which allows you to schedule the garbage collection instantly. This fixes #89 

- Expose `minimumFreeDiskSpaceFraction`
Defaulting to require 10% of free disk space does not make sense for some apps. For example, on a huge disk, say 64GB, there is no reason to require 6GB free space for a 30MB cache.