### PR TITLE
Update SPTPersistentCacheTests.m

### DIFF
--- a/Tests/SPTPersistentCacheTests.m
+++ b/Tests/SPTPersistentCacheTests.m
@@ -1344,12 +1344,16 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
             return kTestEpochTime * 100.0;
         };
         __block BOOL called = NO;
+
+        __weak XCTestExpectation * const expectation = [self expectationWithDescription:@"callback expectation"];
         [self.cache touchDataForKey:key callback:^(SPTPersistentCacheResponse *response) {
             called = YES;
             XCTAssertEqual(response.result, SPTPersistentCacheResponseCodeNotFound);
+            [expectation fulfill];
         } onQueue:dispatch_get_main_queue()];
         break;
     }
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
 }
 
 - (void)testLockDataWithExpiredHeader


### PR DESCRIPTION
`SPTPersistentCacheTests.testTouchDataWithExpiredHeader` fires off a bunch of callbacks to be executed asynchronously. There needs to be a `wait` at the end of the test to ensure they've all completed, otherwise `XCTAssertEqual` may be called outside of a test invocation which causes a fatal exception and crashes the test run.

@8W9aG