### PR TITLE
Don't export an internal constant

### DIFF
--- a/Sources/SPTPersistentCacheOptions.m
+++ b/Sources/SPTPersistentCacheOptions.m
@@ -26,7 +26,7 @@
 
 const NSUInteger SPTPersistentCacheDefaultExpirationTimeSec = 10 * 60;
 const NSUInteger SPTPersistentCacheDefaultGCIntervalSec = 6 * 60 + 3;
-const NSUInteger SPTPersistentCacheDefaultCacheSizeInBytes = 0; // unbounded
+static const NSUInteger SPTPersistentCacheDefaultCacheSizeInBytes = 0; // unbounded
 
 const NSUInteger SPTPersistentCacheMinimumGCIntervalLimit = 60;
 const NSUInteger SPTPersistentCacheMinimumExpirationLimit = 60;


### PR DESCRIPTION
`SPTPersistentCacheDefaultCacheSizeInBytes` is only used in one file and shouldn’t have extern linkage.