### PR TITLE
Fix dynamic framework base SDK

### DIFF
--- a/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
+++ b/SPTPersistentCacheFramework/SPTPersistentCacheFramework.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 				DEFINES_MODULE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-iOS";
 				PRODUCT_NAME = SPTPersistentCache;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				VALID_ARCHS = "i386 x86_64 armv7 arm64 armv7s";
@@ -421,6 +422,7 @@
 				DEFINES_MODULE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.spotify.SPTPersistentCache-iOS";
 				PRODUCT_NAME = SPTPersistentCache;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				VALID_ARCHS = "i386 x86_64 armv7 arm64 armv7s";


### PR DESCRIPTION
The iOS target was missing the Base SDK information, which prevented the framework from being visible in the framework picker for projects wishing to embed the binary.