### PR TITLE
Remove deprecated interfaces

### DIFF
--- a/Sources/SPTPersistentCacheOptions.m
+++ b/Sources/SPTPersistentCacheOptions.m
@@ -156,52 +156,6 @@ static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger m
 @end
 
 
-@implementation SPTPersistentCacheOptions (Deprectated)
-
-- (instancetype)initWithCachePath:(NSString *)cachePath
-                       identifier:(NSString *)cacheIdentifier
-        defaultExpirationInterval:(NSUInteger)defaultExpirationInterval
-         garbageCollectorInterval:(NSUInteger)garbageCollectorInterval
-                            debug:(nullable SPTPersistentCacheDebugCallback)debugCallback
-{
-    self = [self init];
-
-    if (self) {
-        _cachePath = [cachePath copy];
-        _cacheIdentifier = [cacheIdentifier copy];
-
-        _defaultExpirationPeriod = SPTGuardedPropertyValue(defaultExpirationInterval, SPTPersistentCacheMinimumExpirationLimit, @selector(defaultExpirationPeriod), debugCallback);
-        _garbageCollectionInterval = SPTGuardedPropertyValue(garbageCollectorInterval, SPTPersistentCacheMinimumGCIntervalLimit, @selector(garbageCollectionInterval), debugCallback);
-
-        _debugOutput = [debugCallback copy];
-    }
-
-    return self;
-}
-
-- (BOOL)folderSeparationEnabled
-{
-    return self.useDirectorySeparation;
-}
-
-- (void)setFolderSeparationEnabled:(BOOL)folderSeparationEnabled
-{
-    self.useDirectorySeparation = folderSeparationEnabled;
-}
-
-- (NSUInteger)gcIntervalSec
-{
-    return self.garbageCollectionInterval;
-}
-
-- (NSUInteger)defaultExpirationPeriodSec
-{
-    return self.defaultExpirationPeriod;
-}
-
-@end
-
-
 static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger minimumValue, SEL propertySelector, SPTPersistentCacheDebugCallback debugCallback)
 {
     if (proposedValue >= minimumValue) {

--- a/Tests/SPTPersistentCacheOptionsTests.m
+++ b/Tests/SPTPersistentCacheOptionsTests.m
@@ -48,21 +48,6 @@ static NSString * const SPTPersistentCacheOptionsPathComponent = @"com.spotify.t
     XCTAssertNotNil(self.dataCacheOptions.identifierForQueue, @"The identifier for queue shouldn't be nil");
 }
 
-- (void)testMinimumGarbageCollectorIntervalForDeprecatedInit
-{
-    _Pragma("clang diagnostic push");
-    _Pragma("clang diagnostic ignored \"-Wdeprecated\"");
-    SPTPersistentCacheOptions *dataCacheOptions = [[SPTPersistentCacheOptions alloc] initWithCachePath:[NSTemporaryDirectory() stringByAppendingPathComponent:SPTPersistentCacheOptionsPathComponent]
-                                                                                            identifier:@"test"
-                                                                             defaultExpirationInterval:1
-                                                                              garbageCollectorInterval:1
-                                                                                                 debug:nil];
-    _Pragma("clang diagnostic pop");
-
-    XCTAssertEqual(dataCacheOptions.garbageCollectionInterval,
-                   SPTPersistentCacheMinimumGCIntervalLimit);
-}
-
 - (void)testMinimumGarbageCollectorInterval
 {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"debugOuput is executed"];
@@ -80,21 +65,6 @@ static NSString * const SPTPersistentCacheOptionsPathComponent = @"com.spotify.t
 
     XCTAssertEqual(options.garbageCollectionInterval,
                    SPTPersistentCacheMinimumGCIntervalLimit);
-}
-
-- (void)testMinimumDefaultExpirationIntervalForDeprecatedInit
-{
-    _Pragma("clang diagnostic push");
-    _Pragma("clang diagnostic ignored \"-Wdeprecated\"");
-    SPTPersistentCacheOptions *dataCacheOptions = [[SPTPersistentCacheOptions alloc] initWithCachePath:[NSTemporaryDirectory() stringByAppendingPathComponent:SPTPersistentCacheOptionsPathComponent]
-                                                                                            identifier:@"test"
-                                                                             defaultExpirationInterval:1
-                                                                              garbageCollectorInterval:1
-                                                                                                 debug:nil];
-    _Pragma("clang diagnostic pop");
-
-    XCTAssertEqual(dataCacheOptions.defaultExpirationPeriod,
-                   SPTPersistentCacheMinimumExpirationLimit);
 }
 
 - (void)testMinimumDefaultExpiration
@@ -148,50 +118,6 @@ static NSString * const SPTPersistentCacheOptionsPathComponent = @"com.spotify.t
     XCTAssertEqual(original.garbageCollectionInterval, copy.garbageCollectionInterval, @"The values of the property \"garbageCollectionInterval\" should be equal");
     XCTAssertEqual(original.defaultExpirationPeriod, copy.defaultExpirationPeriod, @"The values of the property \"defaultExpirationPeriod\" should be equal");
     XCTAssertEqual(original.sizeConstraintBytes, copy.sizeConstraintBytes, @"The values of the property \"sizeConstraintBytes\" should be equal");
-}
-
-#pragma mark Compatibility Properties for Deprecated Properties
-
-- (void)testFolderSeparationEnabled
-{
-    _Pragma("clang diagnostic push");
-    _Pragma("clang diagnostic ignored \"-Wdeprecated\"");
-
-    SPTPersistentCacheOptions * const options = [SPTPersistentCacheOptions new];
-
-    XCTAssertEqual(options.folderSeparationEnabled, options.useDirectorySeparation);
-
-    options.folderSeparationEnabled = NO;
-    XCTAssertFalse(options.useDirectorySeparation, @"Setting the compatibility property should update the real property");
-    XCTAssertEqual(options.folderSeparationEnabled, options.useDirectorySeparation);
-
-    _Pragma("clang diagnostic pop");
-}
-
-- (void)testGcIntervalSec
-{
-    _Pragma("clang diagnostic push");
-    _Pragma("clang diagnostic ignored \"-Wdeprecated\"");
-
-    SPTPersistentCacheOptions * const options = [SPTPersistentCacheOptions new];
-    options.garbageCollectionInterval = SPTPersistentCacheDefaultGCIntervalSec + 37;
-
-    XCTAssertEqual(options.gcIntervalSec, options.garbageCollectionInterval);
-
-    _Pragma("clang diagnostic pop");
-}
-
-- (void)testDefaultExpirationPeriodSec
-{
-    _Pragma("clang diagnostic push");
-    _Pragma("clang diagnostic ignored \"-Wdeprecated\"");
-
-    SPTPersistentCacheOptions * const options = [SPTPersistentCacheOptions new];
-    options.defaultExpirationPeriod = SPTPersistentCacheDefaultExpirationTimeSec + 37;
-
-    XCTAssertEqual(options.defaultExpirationPeriodSec, options.defaultExpirationPeriod);
-
-    _Pragma("clang diagnostic pop");
 }
 
 #pragma mark Describing objects

--- a/include/SPTPersistentCache/SPTPersistentCacheOptions.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheOptions.h
@@ -203,48 +203,4 @@ FOUNDATION_EXPORT const NSUInteger SPTPersistentCacheMinimumExpirationLimit;
 
 @end
 
-
-#pragma mark - Deprecation Category
-
-/**
- * Methods on `SPTPersistentCacheOptions` that are deprecated and will be removed in a later release.
- */
-@interface SPTPersistentCacheOptions (Deprectated)
-
-/**
- *  Returns a new instance of the class setup with specific values.
- *  @deprecated
- *  @param cachePath Path in the system file for the cache.
- *  @param cacheIdentifier An identifier for the cache.
- *  @param defaultExpirationInterval Default time which have to pass since last file access so file could be candidate
- *  for pruning on next GC.
- *  @param garbageCollectorInterval It is guaranteed that once started GC runs with this interval.
- *  @param debugCallback A callback used for debugging purposes. May be nil.
- */
-- (instancetype)initWithCachePath:(NSString *)cachePath
-                       identifier:(NSString *)cacheIdentifier
-        defaultExpirationInterval:(NSUInteger)defaultExpirationInterval
-         garbageCollectorInterval:(NSUInteger)garbageCollectorInterval
-                            debug:(nullable SPTPersistentCacheDebugCallback)debugCallback DEPRECATED_MSG_ATTRIBUTE("Configure the option instance’s properties instead.");
-
-/**
- *  Compatibility alias for `useDirectorySeparation`.
- *  @seealso useDirectorySeparation
- */
-@property (nonatomic, assign) BOOL folderSeparationEnabled DEPRECATED_MSG_ATTRIBUTE("Use the useDirectorySeparation property instead");
-/**
- *  Compatibility alias for `garbageCollectionInterval`.
- *  @deprecated
- *  @seealso garbageCollectionInterval
- */
-@property (nonatomic, assign, readonly) NSUInteger gcIntervalSec DEPRECATED_MSG_ATTRIBUTE("Use the garbageCollectionInterval property instead");
-/**
- *  Compatibility alias for `defaultExpirationPeriod`.
- *  @deprecated
- *  @seealso defaultExpirationPeriod
- */
-@property (nonatomic, assign, readonly) NSUInteger defaultExpirationPeriodSec DEPRECATED_MSG_ATTRIBUTE("Use the defaultExpirationPeriod property instead");
-
-@end
-
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This has been deprecated for [over two years](https://github.com/spotify/SPTPersistentCache/pull/63).

If we merge this it’s a semver MAJOR change, so I guess the question is if we want anything else in a 2.0.0 release.

@rastersize @8W9aG @dflems 