### PR TITLE
Fix Xcode 10 Build Issue

### DIFF
--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -733,7 +733,7 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
                 const char *errorString = strerror(errorNumber);
                 error = [NSError errorWithDomain:NSPOSIXErrorDomain
                                             code:errorNumber
-                                        userInfo:@{ NSLocalizedDescriptionKey: @(errorString) }];
+                                        userInfo:@{ NSLocalizedDescriptionKey: (NSString*)@(errorString) }];
             }
 
             [self debugOutput:@"PersistentDataCache: Error not enough data to read the header of file path:%@ , error:%@",

--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -733,7 +733,7 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
                 const char *errorString = strerror(errorNumber);
                 error = [NSError errorWithDomain:NSPOSIXErrorDomain
                                             code:errorNumber
-                                        userInfo:@{ NSLocalizedDescriptionKey: (NSString*)@(errorString) }];
+                                        userInfo:@{ NSLocalizedDescriptionKey: (id)@(errorString) }];
             }
 
             [self debugOutput:@"PersistentDataCache: Error not enough data to read the header of file path:%@ , error:%@",


### PR DESCRIPTION
When using Carthage to build the SPTPersistentCache with Xcode 10, an error is logged:
```
SPTPersistentCache.m:736:80: Implicit conversion from nullable pointer 'NSString * _Nullable' to non-nullable pointer type 'ObjectType _Nonnull' (aka 'id')
```

This commit fixes the issue by ensuring that a raw `(id)` cast is used to place the error string into the dictionary.