### PR TITLE
Fix implicit nullable pointer conversion

### DIFF
--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -730,10 +730,10 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
             NSError *error = [NSError spt_persistentDataCacheErrorWithCode:SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader];
             if (readBytes == -1) {
                 const int errorNumber = errno;
-                const char *errorString = strerror(errorNumber);
+                NSString *errorDescription = @(strerror(errorNumber));
                 error = [NSError errorWithDomain:NSPOSIXErrorDomain
                                             code:errorNumber
-                                        userInfo:@{ NSLocalizedDescriptionKey: @(errorString) }];
+                                        userInfo:@{ NSLocalizedDescriptionKey: errorDescription }];
             }
 
             [self debugOutput:@"PersistentDataCache: Error not enough data to read the header of file path:%@ , error:%@",


### PR DESCRIPTION
Fixes a nullability error in Xcode 10 and keeps the `errorDescription` usage consistent with the rest of the file.