### PR TITLE
Update development region

### DIFF
--- a/SPTPersistentCache.xcodeproj/project.pbxproj
+++ b/SPTPersistentCache.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 			};
 			buildConfigurationList = 0510FF0E1BA2FF7A00ED0766 /* Build configuration list for PBXProject "SPTPersistentCache" */;
 			compatibilityVersion = "Xcode 6.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,


### PR DESCRIPTION
Fixes a warning in Xcode 10.2.

@dflems 