### PR TITLE
add note about calling `scheduleGarbageCollector` to start GC

### DIFF
--- a/include/SPTPersistentCache/SPTPersistentCacheOptions.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheOptions.h
@@ -158,6 +158,7 @@ FOUNDATION_EXPORT const NSUInteger SPTPersistentCacheMinimumExpirationLimit;
 
 /**
  Garbage collection (GC) interval in seconds. It is guaranteed that once started the GC runs with this interval.
+ @note To start GC call `scheduleGarbageCollector` on `SPTPersistentCache` object.
  @discussion Its recommended to use `SPTPersistentCacheDefaultGCIntervalSec` constant if unsure. The
  implementation will make sure the value isn’t below the minimum (`SPTPersistentCacheMinimumGCIntervalLimit`).
  @note Defaults to `SPTPersistentCacheDefaultGCIntervalSec`.


### PR DESCRIPTION
### What?

- Improves documentation by adding a note about calling `scheduleGarbageCollector` to start GC.

### Why?

- From documentation it is not clear how to start GC after setting `garbageCollectionInterval`.