### PR TITLE
fix bug when path contains directory with space

### DIFF
--- a/SPTPersistentCacheDemo/SPTPersistentCacheDemo/MasterViewController.m
+++ b/SPTPersistentCacheDemo/SPTPersistentCacheDemo/MasterViewController.m
@@ -156,7 +156,7 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
     }
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
-    NSURL *url = [NSURL URLWithString:imageURL];
+    NSURL *url = [NSURL fileURLWithPath:imageURL];
 
     NSAssert(url != nil, @"Couldn’t create a wellformed URL from the image URL string \"%@\"", imageURL);
 

--- a/Sources/SPTPersistentCache.m
+++ b/Sources/SPTPersistentCache.m
@@ -459,7 +459,7 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
 - (NSUInteger)lockedItemsSizeInBytes
 {
     NSUInteger size = 0;
-    NSURL *urlPath = [NSURL URLWithString:self.options.cachePath];
+    NSURL *urlPath = [NSURL fileURLWithPath:self.options.cachePath];
     NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtURL:urlPath
                                                   includingPropertiesForKeys:@[NSURLIsDirectoryKey]
                                                                      options:NSDirectoryEnumerationSkipsHiddenFiles
@@ -854,7 +854,7 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
 {
     [self debugOutput:@"PersistentDataCache: Run GC with forceExpire:%d forceLock:%d", forceExpire, forceLocked];
 
-    NSURL *urlPath = [NSURL URLWithString:self.options.cachePath];
+    NSURL *urlPath = [NSURL fileURLWithPath:self.options.cachePath];
     NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtURL:urlPath
                                                   includingPropertiesForKeys:@[NSURLIsDirectoryKey]
                                                                      options:NSDirectoryEnumerationSkipsHiddenFiles
@@ -990,7 +990,7 @@ void SPTPersistentCacheSafeDispatch(_Nullable dispatch_queue_t queue, _Nonnull d
 
 - (NSMutableArray *)storedImageNamesAndAttributes
 {
-    NSURL *urlPath = [NSURL URLWithString:self.options.cachePath];
+    NSURL *urlPath = [NSURL fileURLWithPath:self.options.cachePath];
 
     // Enumerate the directory (specified elsewhere in your code)
     // Ignore hidden files

--- a/Sources/SPTPersistentCacheFileManager.m
+++ b/Sources/SPTPersistentCacheFileManager.m
@@ -89,7 +89,7 @@ const NSUInteger SPTPersistentCacheFileManagerSubDirNameLength = 2;
 
 - (void)removeAllData
 {
-    NSURL *urlPath = [NSURL URLWithString:self.options.cachePath];
+    NSURL *urlPath = [NSURL fileURLWithPath:self.options.cachePath];
     
     NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtURL:urlPath
                                                   includingPropertiesForKeys:@[NSURLIsDirectoryKey]
@@ -136,7 +136,7 @@ const NSUInteger SPTPersistentCacheFileManagerSubDirNameLength = 2;
 - (NSUInteger)totalUsedSizeInBytes
 {
     NSUInteger size = 0;
-    NSURL *urlPath = [NSURL URLWithString:self.options.cachePath];
+    NSURL *urlPath = [NSURL fileURLWithPath:self.options.cachePath];
     NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtURL:urlPath
                                                   includingPropertiesForKeys:@[NSURLIsDirectoryKey]
                                                                      options:NSDirectoryEnumerationSkipsHiddenFiles

--- a/Tests/SPTPersistentCacheFileManagerTests.m
+++ b/Tests/SPTPersistentCacheFileManagerTests.m
@@ -26,7 +26,7 @@
 #import <objc/runtime.h>
 
 
-static NSString * const SPTPersistentCacheFileManagerTestsCachePath = @"test_directory";
+static NSString * const SPTPersistentCacheFileManagerTestsCachePath = @"test directory";
 
 
 #pragma mark -

--- a/Tests/SPTPersistentCacheTests.m
+++ b/Tests/SPTPersistentCacheTests.m
@@ -216,7 +216,7 @@ typedef NSTimeInterval (^SPTPersistentCacheCurrentTimeSecCallback)(void);
     }
 
     self.cachePath = [NSTemporaryDirectory() stringByAppendingPathComponent:
-                              [NSString stringWithFormat:@"pdc-%@.tmp", [[NSProcessInfo processInfo] globallyUniqueString]]];
+                              [NSString stringWithFormat:@"pdc %@.tmp", [[NSProcessInfo processInfo] globallyUniqueString]]];
 
     NSLog(@"%@", self.cachePath);
 
@@ -1975,7 +1975,7 @@ SPTPersistentCacheLoadingErrorNotEnoughDataToGetHeader,
 - (NSUInteger)getFilesNumberAtPath:(NSString *)path
 {
     NSUInteger count = 0;
-    NSURL *urlPath = [NSURL URLWithString:path];
+    NSURL *urlPath = [NSURL fileURLWithPath:path];
     NSDirectoryEnumerator *dirEnumerator = [[NSFileManager defaultManager] enumeratorAtURL:urlPath
                                                                 includingPropertiesForKeys:@[NSURLIsDirectoryKey]
                                                                                    options:NSDirectoryEnumerationSkipsHiddenFiles


### PR DESCRIPTION
### What?

Uses `fileURLWithPath` instead of `URLWithString`.

### Why?

[For file system paths we should use `fileURLWithPath`](https://developer.apple.com/documentation/foundation/nsurl/1572047-urlwithstring?language=objc):

<img width="755" alt="Screenshot 2020-06-18 at 09 30 55" src="https://user-images.githubusercontent.com/3186691/84991162-6e06fc00-b146-11ea-85df-10d553dadcc8.png">

For example `URLWithString` fails if path contains `Application Support` directory.

