### PR TITLE
Fix incorrect enum usage

### DIFF
--- a/Tests/SPTPersistentCachePerformanceTests.m
+++ b/Tests/SPTPersistentCachePerformanceTests.m
@@ -120,11 +120,11 @@ static const int SPTPersistentCachePerformanceIterationCount = 200;
     SPTPersistentCacheOptions *options = [[SPTPersistentCacheOptions alloc] init];
     options.cachePath = self.cachePath;
     options.readPriority = NSOperationQueuePriorityVeryHigh;
-    options.readPriority = NSOperationQualityOfServiceUserInteractive;
+    options.readQualityOfService = NSOperationQualityOfServiceUserInteractive;
     options.writePriority = NSOperationQueuePriorityNormal;
-    options.writePriority = NSOperationQualityOfServiceUserInitiated;
+    options.writeQualityOfService = NSOperationQualityOfServiceUserInitiated;
     options.deletePriority = NSOperationQueuePriorityLow;
-    options.deletePriority = NSOperationQualityOfServiceUtility;
+    options.deleteQualityOfService = NSOperationQualityOfServiceUtility;
     options.timingCallback = ^(NSString *key, SPTPersistentCacheDebugMethodType method, SPTPersistentCacheDebugTimingType type, uint64_t machTime){
         NSMutableArray<SPTPersistentCacheTiming *> *timings = nil;
         switch (method) {


### PR DESCRIPTION
This was probably a copypasta error from #81. Xcode 12.5 properly emits a diagnostic for this now.