### PR TITLE
Make min free disk space portion adjustable by clients of the library

### DIFF
--- a/Sources/SPTPersistentCacheFileManager.m
+++ b/Sources/SPTPersistentCacheFileManager.m
@@ -22,8 +22,6 @@
 #import "SPTPersistentCacheDebugUtilities.h"
 #import <SPTPersistentCache/SPTPersistentCacheOptions.h>
 
-static const double SPTPersistentCacheFileManagerMinFreeDiskSpace = 0.1;
-
 const NSUInteger SPTPersistentCacheFileManagerSubDirNameLength = 2;
 
 @implementation SPTPersistentCacheFileManager
@@ -185,8 +183,7 @@ const NSUInteger SPTPersistentCacheFileManagerSubDirNameLength = 2;
         
         SPTPersistentCacheDiskSize totalSpace = fileSystemSize.longLongValue;
         SPTPersistentCacheDiskSize freeSpace = fileSystemFreeSpace.longLongValue + currentCacheSize;
-        SPTPersistentCacheDiskSize proposedCacheSize = freeSpace - llrint(totalSpace *
-                                                                              SPTPersistentCacheFileManagerMinFreeDiskSpace);
+        SPTPersistentCacheDiskSize proposedCacheSize = freeSpace - llrint(totalSpace * self.options.minFreeDiskSpacePortion);
         
         tempCacheSize = MAX(0, proposedCacheSize);
         

--- a/Sources/SPTPersistentCacheOptions.m
+++ b/Sources/SPTPersistentCacheOptions.m
@@ -27,6 +27,7 @@
 const NSUInteger SPTPersistentCacheDefaultExpirationTimeSec = 10 * 60;
 const NSUInteger SPTPersistentCacheDefaultGCIntervalSec = 6 * 60 + 3;
 static const NSUInteger SPTPersistentCacheDefaultCacheSizeInBytes = 0; // unbounded
+static const double SPTPersistentCacheDefaultMinFreeDiskSpacePortion = 0.1;
 
 const NSUInteger SPTPersistentCacheMinimumGCIntervalLimit = 60;
 const NSUInteger SPTPersistentCacheMinimumExpirationLimit = 60;
@@ -55,6 +56,7 @@ static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger m
         _garbageCollectionInterval = SPTPersistentCacheDefaultGCIntervalSec;
         _defaultExpirationPeriod = SPTPersistentCacheDefaultExpirationTimeSec;
         _sizeConstraintBytes = SPTPersistentCacheDefaultCacheSizeInBytes;
+        _minFreeDiskSpacePortion = SPTPersistentCacheDefaultMinFreeDiskSpacePortion;
         _maxConcurrentOperations = NSOperationQueueDefaultMaxConcurrentOperationCount;
         _writePriority = NSOperationQueuePriorityNormal;
         _writeQualityOfService = NSQualityOfServiceDefault;
@@ -117,6 +119,7 @@ static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger m
     copy.garbageCollectionInterval = self.garbageCollectionInterval;
     copy.defaultExpirationPeriod = self.defaultExpirationPeriod;
     copy.sizeConstraintBytes = self.sizeConstraintBytes;
+    copy.minFreeDiskSpacePortion = self.minFreeDiskSpacePortion;
 
     copy.debugOutput = self.debugOutput;
     copy.timingCallback = self.timingCallback;
@@ -150,7 +153,8 @@ static NSUInteger SPTGuardedPropertyValue(NSUInteger proposedValue, NSUInteger m
                                                @(self.useDirectorySeparation), @"use-directory-separation",
                                                @(self.garbageCollectionInterval), @"garbage-collection-interval",
                                                @(self.defaultExpirationPeriod), @"default-expiration-period",
-                                               @(self.sizeConstraintBytes), @"size-constraint-bytes");
+                                               @(self.sizeConstraintBytes), @"size-constraint-bytes",
+                                               @(self.minFreeDiskSpacePortion), @"min-free-disk-space-portion");
 }
 
 @end

--- a/include/SPTPersistentCache/SPTPersistentCacheOptions.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheOptions.h
@@ -178,6 +178,11 @@ FOUNDATION_EXPORT const NSUInteger SPTPersistentCacheMinimumExpirationLimit;
  */
 @property (nonatomic, assign) NSUInteger sizeConstraintBytes;
 /**
+ Portion of the total disk space to always leave free on the device. Only works if `sizeConstraintBytes` is not `0`.
+ @note Defaults to `0.1`.
+ */
+@property (nonatomic, assign) double minFreeDiskSpacePortion;
+/**
  The queue priority for garbage collection. Defaults to NSOperationQueuePriorityLow.
  */
 @property (nonatomic) NSOperationQueuePriority garbageCollectionPriority;


### PR DESCRIPTION
Currently, `SPTPersistentCacheFileManager` calculates the minimum free disk space by 0.1 * total disk space. This is unreasonable for the sizes of the current device storages. This pull request makes it possible for clients to change the portion of the total disk space that should be free.