### PR TITLE
Fix 'occured' -> 'occurred' typo in SPTPersistentCacheResponse doc

### DIFF
--- a/include/SPTPersistentCache/SPTPersistentCacheResponse.h
+++ b/include/SPTPersistentCache/SPTPersistentCacheResponse.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSInteger, SPTPersistentCacheResponseCode) {
      */
     SPTPersistentCacheResponseCodeNotFound,
     /**
-     Indicates error occured during requested operation. The record field of SPTPersistentCacheResponse would be nil.
+     Indicates error occurred during requested operation. The record field of SPTPersistentCacheResponse would be nil.
      The error mustn't be nil and specify exact error.
      */
     SPTPersistentCacheResponseCodeOperationError


### PR DESCRIPTION
Doxygen comment on the error-response enum member in `include/SPTPersistentCache/SPTPersistentCacheResponse.h:43` read `Indicates error occured during requested operation`. Doc-only Obj-C change.